### PR TITLE
Implemented spectral report execution on build

### DIFF
--- a/src/Workleap.OpenApi.MSBuild/ISpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/ISpectralManager.cs
@@ -2,5 +2,7 @@ namespace Workleap.OpenApi.MSBuild;
 
 public interface ISpectralManager
 {
-    public Task InstallSpectralAsync(CancellationToken cancellationToken);
+    public Task<string> InstallSpectralAsync(CancellationToken cancellationToken);
+
+    public Task RunSpectralAsync(IEnumerable<string> swaggerDocumentPaths, string rulesetUrl, string executableFilename, CancellationToken cancellationToken);
 }

--- a/src/Workleap.OpenApi.MSBuild/ISpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/ISpectralManager.cs
@@ -2,7 +2,7 @@ namespace Workleap.OpenApi.MSBuild;
 
 public interface ISpectralManager
 {
-    public Task<string> InstallSpectralAsync(CancellationToken cancellationToken);
+    public Task InstallSpectralAsync(CancellationToken cancellationToken);
 
-    public Task RunSpectralAsync(IEnumerable<string> swaggerDocumentPaths, string rulesetUrl, string executableFilename, CancellationToken cancellationToken);
+    public Task RunSpectralAsync(IEnumerable<string> swaggerDocumentPaths, string rulesetUrl, CancellationToken cancellationToken);
 }

--- a/src/Workleap.OpenApi.MSBuild/ISwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/ISwaggerManager.cs
@@ -2,9 +2,9 @@ namespace Workleap.OpenApi.MSBuild;
 
 public interface ISwaggerManager
 {
-    Task RunSwaggerAsync(string[] openApiSwaggerDocumentNames, CancellationToken cancellationToken);
+    Task<IEnumerable<string>> RunSwaggerAsync(string[] openApiSwaggerDocumentNames, CancellationToken cancellationToken);
 
     Task InstallSwaggerCliAsync(CancellationToken cancellationToken);
 
-    Task GenerateOpenApiSpecAsync(string swaggerExePath, string outputOpenApiSpecPath, string documentName, CancellationToken cancellationToken);
+    Task<string> GenerateOpenApiSpecAsync(string swaggerExePath, string outputOpenApiSpecPath, string documentName, CancellationToken cancellationToken);
 }

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -29,8 +29,12 @@ internal sealed class SpectralManager : ISpectralManager
 
         this.ExecutablePath = GetSpectralFileName();
         var url = $"https://github.com/stoplightio/spectral/releases/download/v{SpectralVersion}/{this.ExecutablePath}";
+        var destination = Path.Combine(this._spectralDirectory, this.ExecutablePath);
 
-        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._spectralDirectory, this.ExecutablePath), cancellationToken);
+        if (!File.Exists(destination))
+        {
+            await this._httpClientWrapper.DownloadFileToDestinationAsync(url, destination, cancellationToken);
+        }
     }
 
     public async Task RunSpectralAsync(IEnumerable<string> swaggerDocumentPaths, string rulesetUrl, CancellationToken cancellationToken)

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -111,13 +111,9 @@ internal sealed class SpectralManager : ISpectralManager
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            var chmodExitCode = await this._processWrapper.RunProcessAsync("/bin/bash", new[] { "-c", "chmod", "+x", spectralExecutePath }, cancellationToken);
-            if (chmodExitCode != 0)
-            {
-                this._loggerWrapper.LogMessage("Failed to provide execute permission to {0}", spectralExecutePath);
-            }
+            await this.AssignExecutePermission(spectralExecutePath, cancellationToken);
         }
-        
+
         var exitCode = await this._processWrapper.RunProcessAsync(spectralExecutePath, new[] { "lint", swaggerDocumentPath, "--ruleset", rulesetUrl, "--format", "html", "--output.html", htmlReportPath }, cancellationToken);
         if (exitCode != 0)
         {
@@ -125,5 +121,14 @@ internal sealed class SpectralManager : ISpectralManager
         }
 
         this._loggerWrapper.LogMessage("Spectral report generated. {0}", htmlReportPath);
+    }
+
+    private async Task AssignExecutePermission(string spectralExecutePath, CancellationToken cancellationToken)
+    {
+        var chmodExitCode = await this._processWrapper.RunProcessAsync("/bin/bash", new[] { "-c",  $"chmod +x {spectralExecutePath}" }, cancellationToken);
+        if (chmodExitCode != 0)
+        {
+            this._loggerWrapper.LogMessage("Failed to provide execute permission to {0}", spectralExecutePath);
+        }
     }
 }

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -114,5 +114,7 @@ internal sealed class SpectralManager : ISpectralManager
         {
             throw new OpenApiTaskFailedException($"Spectral report for {swaggerDocumentPath} could not be created.");
         }
+
+        this._loggerWrapper.LogMessage("Spectral report generated. {0}", htmlReportPath);
     }
 }

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -128,7 +128,7 @@ internal sealed class SpectralManager : ISpectralManager
         var chmodExitCode = await this._processWrapper.RunProcessAsync("/bin/bash", new[] { "-c",  $"chmod +x {spectralExecutePath}" }, cancellationToken);
         if (chmodExitCode != 0)
         {
-            this._loggerWrapper.LogMessage("Failed to provide execute permission to {0}", spectralExecutePath);
+            throw new OpenApiTaskFailedException($"Failed to provide execute permission to {spectralExecutePath}");
         }
     }
 }

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -1,5 +1,4 @@
 using System.Runtime.InteropServices;
-using Microsoft.Build.Framework;
 
 namespace Workleap.OpenApi.MSBuild;
 
@@ -9,23 +8,44 @@ internal sealed class SpectralManager : ISpectralManager
 
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly IHttpClientWrapper _httpClientWrapper;
-    private readonly string _toolDirectory;
+    private readonly string _spectralDirectory;
+    private readonly string _openApiToolsDirectory;
+    private readonly IProcessWrapper _processWrapper;
 
-    public SpectralManager(LoggerWrapper loggerWrapper, string openApiToolsDirectoryPath, IHttpClientWrapper httpClientWrapper)
+    public SpectralManager(ILoggerWrapper loggerWrapper, string openApiToolsDirectoryPath, IHttpClientWrapper httpClientWrapper, IProcessWrapper processWrapper)
     {
         this._loggerWrapper = loggerWrapper;
         this._httpClientWrapper = httpClientWrapper;
-        this._toolDirectory = Path.Combine(openApiToolsDirectoryPath, "spectral", SpectralVersion);
+        this._openApiToolsDirectory = openApiToolsDirectoryPath;
+        this._spectralDirectory = Path.Combine(openApiToolsDirectoryPath, "spectral", SpectralVersion);
+        this._processWrapper = processWrapper;
     }
 
-    public async Task InstallSpectralAsync(CancellationToken cancellationToken)
+    public async Task<string> InstallSpectralAsync(CancellationToken cancellationToken)
     {
-        Directory.CreateDirectory(this._toolDirectory);
+        Directory.CreateDirectory(this._spectralDirectory);
 
         var executableFileName = GetSpectralFileName();
         var url = $"https://github.com/stoplightio/spectral/releases/download/v{SpectralVersion}/{executableFileName}";
 
-        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._toolDirectory, executableFileName), cancellationToken);
+        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._spectralDirectory, executableFileName), cancellationToken);
+        return executableFileName;
+    }
+
+    public async Task RunSpectralAsync(IEnumerable<string> swaggerDocumentPaths, string rulesetUrl, string executableFilename, CancellationToken cancellationToken)
+    {
+        this._loggerWrapper.LogMessage("Starting Spectral report generation.");
+        
+        var spectralExecutePath = Path.Combine(this._spectralDirectory, executableFilename);
+        var reportsPath = Path.Combine(this._openApiToolsDirectory, "reports");
+        Directory.CreateDirectory(reportsPath);
+
+        foreach (var documentPath in swaggerDocumentPaths)
+        {
+            var documentName = Path.GetFileNameWithoutExtension(documentPath);
+            var outputSpectralReportName = $"spectral-{documentName}.html";
+            await this.GenerateSpectralReport(documentPath, rulesetUrl, spectralExecutePath, Path.Combine(reportsPath, outputSpectralReportName), cancellationToken);
+        }
     }
 
     private static string GetSpectralFileName()
@@ -85,5 +105,14 @@ internal sealed class SpectralManager : ISpectralManager
         }
 
         throw new OpenApiTaskFailedException("Unknown processor architecture encountered");
+    }
+
+    private async Task GenerateSpectralReport(string swaggerDocumentPath, string rulesetUrl, string spectralExecutePath, string htmlReportPath, CancellationToken cancellationToken)
+    {
+        var exitCode = await this._processWrapper.RunProcessAsync(spectralExecutePath, new[] { "lint", swaggerDocumentPath, "--ruleset", rulesetUrl, "--format", "html", "--output.html", htmlReportPath }, cancellationToken);
+        if (exitCode != 0)
+        {
+            throw new OpenApiTaskFailedException($"Spectral report for {swaggerDocumentPath} could not be created.");
+        }
     }
 }

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Build.Framework;
+using Microsoft.Build.Framework;
 
 namespace Workleap.OpenApi.MSBuild;
 
@@ -28,10 +28,10 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
     {
         var loggerWrapper = new LoggerWrapper(this.Log);
         var processWrapper = new ProcessWrapper(this.OpenApiToolsDirectoryPath);
-        var swaggerManager = new SwaggerManager(processWrapper, loggerWrapper, this.OpenApiToolsDirectoryPath, this.OpenApiToolsDirectoryPath);
+        var swaggerManager = new SwaggerManager(processWrapper, loggerWrapper, this.OpenApiToolsDirectoryPath, this.OpenApiWebApiAssemblyPath);
         using var httpClientWrapper = new HttpClientWrapper();
 
-        var spectralManager = new SpectralManager(loggerWrapper, this.OpenApiToolsDirectoryPath, httpClientWrapper);
+        var spectralManager = new SpectralManager(loggerWrapper, this.OpenApiToolsDirectoryPath, httpClientWrapper, processWrapper);
 
         this.Log.LogMessage(MessageImportance.Low, "{0} = '{1}'", nameof(this.OpenApiWebApiAssemblyPath), this.OpenApiWebApiAssemblyPath);
         this.Log.LogMessage(MessageImportance.Low, "{0} = '{1}'", nameof(this.OpenApiToolsDirectoryPath), this.OpenApiToolsDirectoryPath);
@@ -51,13 +51,14 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
             await this.GeneratePublicNugetSource();
 
             await swaggerManager.InstallSwaggerCliAsync(cancellationToken);
-            await spectralManager.InstallSpectralAsync(cancellationToken);
+            var spectralExecutableFile = await spectralManager.InstallSpectralAsync(cancellationToken);
 
-            // await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken);
+            var swaggerDocPaths = await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken);
+            await spectralManager.RunSpectralAsync(swaggerDocPaths, this.OpenApiSpectralRulesetUrl, spectralExecutableFile, cancellationToken);
         }
         catch (OpenApiTaskFailedException e)
         {
-            this.Log.LogWarning("An error occured while validating the OpenAPI specification: {0}", e.Message);
+            this.Log.LogWarning("An error occurred while validating the OpenAPI specification: {0}", e.Message);
         }
 
         return true;

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -51,10 +51,10 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
             await this.GeneratePublicNugetSource();
 
             await swaggerManager.InstallSwaggerCliAsync(cancellationToken);
-            var spectralExecutableFile = await spectralManager.InstallSpectralAsync(cancellationToken);
+            await spectralManager.InstallSpectralAsync(cancellationToken);
 
             var swaggerDocPaths = await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken);
-            await spectralManager.RunSpectralAsync(swaggerDocPaths, this.OpenApiSpectralRulesetUrl, spectralExecutableFile, cancellationToken);
+            await spectralManager.RunSpectralAsync(swaggerDocPaths, this.OpenApiSpectralRulesetUrl, cancellationToken);
         }
         catch (OpenApiTaskFailedException e)
         {


### PR DESCRIPTION
## Changes
- Enabled Swagger generation on build
- Implemented Spectral report generation and output it as `html` to `/reports` directory
- Changed method signatures