### PR TITLE
Implemented Oasdiff build run

### DIFF
--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -4,6 +4,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -4,7 +4,6 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
-    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WebApiDebugger/openapi-v1.yaml
+++ b/src/WebApiDebugger/openapi-v1.yaml
@@ -12,17 +12,7 @@ paths:
         '200':
           description: Success --- New Description
           content:
-            text/plain:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/WeatherForecast'
             application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/WeatherForecast'
-            text/json:
               schema:
                 type: array
                 items:

--- a/src/WebApiDebugger/openapi-v1.yaml
+++ b/src/WebApiDebugger/openapi-v1.yaml
@@ -1,0 +1,48 @@
+openapi: 3.0.1
+info:
+  title: 'WebApiDebugger'
+  version: '1.0'
+paths:
+  /WeatherForecast:
+    get:
+      tags:
+        - WeatherForecast
+      operationId: GetWeatherForecast
+      responses:
+        '200':
+          description: Success --- New Description
+          content:
+            text/plain:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherForecast'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherForecast'
+            text/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherForecast'
+components:
+  schemas:
+    WeatherForecast:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date-time
+        temperatureC:
+          type: integer
+          format: int32
+        temperatureF:
+          type: integer
+          format: int32
+          readOnly: true
+        summary:
+          type: string
+          nullable: true
+      additionalProperties: false

--- a/src/Workleap.OpenApi.MSBuild/HttpClientWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/HttpClientWrapper.cs
@@ -43,7 +43,7 @@ internal sealed class HttpClientWrapper : IHttpClientWrapper, IDisposable
     {
         await using var fileTarget = new FileStream(destination, FileMode.Create, FileAccess.Write, FileShare.None);
 
-        await responseStream.CopyToAsync(fileTarget, 81920, cancellationToken);
+        await responseStream.CopyToAsync(fileTarget, cancellationToken);
     }
 
     public void Dispose()

--- a/src/Workleap.OpenApi.MSBuild/HttpClientWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/HttpClientWrapper.cs
@@ -13,11 +13,11 @@ internal sealed class HttpClientWrapper : IHttpClientWrapper, IDisposable
 
         try
         {
-            using var responseStream = await this._httpClient.GetStreamAsync(url);
+            await using var responseStream = await this._httpClient.GetStreamAsync(url);
 
             if (responseStream == null)
             {
-                using var retryResponseStream = await this._httpClient.GetStreamAsync(url);
+                await using var retryResponseStream = await this._httpClient.GetStreamAsync(url);
                 if (retryResponseStream != null)
                 {
                     await SaveFileFromResponseAsync(destination, retryResponseStream, cancellationToken);
@@ -41,7 +41,7 @@ internal sealed class HttpClientWrapper : IHttpClientWrapper, IDisposable
 
     private static async Task SaveFileFromResponseAsync(string destination, Stream responseStream, CancellationToken cancellationToken)
     {
-        using var fileTarget = new FileStream(destination, FileMode.Create, FileAccess.Write, FileShare.None);
+        await using var fileTarget = new FileStream(destination, FileMode.Create, FileAccess.Write, FileShare.None);
 
         await responseStream.CopyToAsync(fileTarget, 81920, cancellationToken);
     }

--- a/src/Workleap.OpenApi.MSBuild/IOasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/IOasdiffManager.cs
@@ -3,4 +3,6 @@ namespace Workleap.OpenApi.MSBuild;
 internal interface IOasdiffManager
 {
     Task InstallOasdiffAsync(CancellationToken cancellationToken);
+    
+    Task RunOasdiffAsync(IEnumerable<string> openApiSpecificationFiles, CancellationToken cancellationToken);
 }

--- a/src/Workleap.OpenApi.MSBuild/IOasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/IOasdiffManager.cs
@@ -4,5 +4,5 @@ internal interface IOasdiffManager
 {
     Task InstallOasdiffAsync(CancellationToken cancellationToken);
     
-    Task RunOasdiffAsync(IEnumerable<string> openApiSpecificationFiles, CancellationToken cancellationToken);
+    Task RunOasdiffAsync(IEnumerable<string> openApiSpecFiles, IEnumerable<string> generatedOpenApiSpecFiles, CancellationToken cancellationToken);
 }

--- a/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
@@ -4,7 +4,7 @@ namespace Workleap.OpenApi.MSBuild;
 
 internal sealed class LoggerWrapper : ILoggerWrapper
 {
-    private TaskLoggingHelper _taskLoggingHelper;
+    private readonly TaskLoggingHelper _taskLoggingHelper;
 
     public LoggerWrapper(TaskLoggingHelper helper) => this._taskLoggingHelper = helper;
 

--- a/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
@@ -4,20 +4,13 @@ namespace Workleap.OpenApi.MSBuild;
 
 internal sealed class LoggerWrapper : ILoggerWrapper
 {
-    public LoggerWrapper(TaskLoggingHelper helper)
-    {
-        this.Helper = helper;
-    }
+    private TaskLoggingHelper _taskLoggingHelper;
 
-    private TaskLoggingHelper Helper { get; }
+    public LoggerWrapper(TaskLoggingHelper helper) => this._taskLoggingHelper = helper;
 
     public void LogWarning(string message, params object[] messageArgs)
-    {
-        this.Helper.LogWarning(message, messageArgs);
-    }
+        => this._taskLoggingHelper.LogWarning(message, messageArgs);
 
     public void LogMessage(string message, params object[] messageArgs)
-    {
-        this.Helper.LogMessage(message, messageArgs);
-    }
+        => this._taskLoggingHelper.LogMessage(message, messageArgs);
 }

--- a/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
@@ -9,7 +9,7 @@ internal sealed class LoggerWrapper : ILoggerWrapper
         this.Helper = helper;
     }
 
-    public TaskLoggingHelper Helper { get; set; }
+    private TaskLoggingHelper Helper { get; }
 
     public void LogWarning(string message, params object[] messageArgs)
     {

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -5,6 +5,7 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class OasdiffManager : IOasdiffManager
 {
     private const string OasdiffVersion = "1.9.2";
+    private const string OasdiffDownloadUrlFormat = "https://github.com/Tufin/oasdiff/releases/download/v{0}/{1}";
 
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly IHttpClientWrapper _httpClientWrapper;
@@ -28,7 +29,7 @@ internal sealed class OasdiffManager : IOasdiffManager
         Directory.CreateDirectory(this._oasdiffDirectory);
 
         var oasdiffFileName = GetOasdiffFileName();
-        var url = $"https://github.com/Tufin/oasdiff/releases/download/v{OasdiffVersion}/{oasdiffFileName}";
+        var url = string.Format(OasdiffDownloadUrlFormat, OasdiffVersion, oasdiffFileName);
 
         await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._oasdiffDirectory, oasdiffFileName), cancellationToken);
         await this.DecompressDownloadedFileAsync(oasdiffFileName, cancellationToken);

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -54,8 +54,9 @@ internal sealed class OasdiffManager : IOasdiffManager
 
     private async Task DecompressDownloadedFileAsync(string oasdiffFileName, CancellationToken cancellationToken)
     {
+        var alreadyDecompressed = Path.Combine(this._oasdiffDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "oasdiff.exe" : "oasdiff");
         var pathToCompressedFile = Path.Combine(this._oasdiffDirectory, oasdiffFileName);
-        if (File.Exists(pathToCompressedFile))
+        if (File.Exists(alreadyDecompressed))
         {
             return;
         }

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -6,47 +6,76 @@ internal sealed class OasdiffManager : IOasdiffManager
 {
     private const string OasdiffVersion = "1.9.2";
 
+    private readonly ILoggerWrapper _loggerWrapper;
     private readonly IHttpClientWrapper _httpClientWrapper;
     private readonly IProcessWrapper _processWrapper;
     private readonly string _openApiToolsDirectory;
     private readonly string _oasdiffDirectory;
 
-    public OasdiffManager(IProcessWrapper processWrapper, string openApiToolsDirectoryPath, IHttpClientWrapper httpClientWrapper)
+    public OasdiffManager(ILoggerWrapper loggerWrapper, IProcessWrapper processWrapper, string openApiToolsDirectoryPath, IHttpClientWrapper httpClientWrapper)
     {
+        this._loggerWrapper = loggerWrapper;
         this._httpClientWrapper = httpClientWrapper;
         this._processWrapper = processWrapper;
         this._openApiToolsDirectory = openApiToolsDirectoryPath;
         this._oasdiffDirectory = Path.Combine(openApiToolsDirectoryPath, "oasdiff", OasdiffVersion);
     }
+
+    private bool SkipRun { get; set; }
     
     public async Task InstallOasdiffAsync(CancellationToken cancellationToken)
     {
-        Directory.CreateDirectory(this._oasdiffDirectory);
+        try
+        {
+            this._loggerWrapper.LogMessage("Starting Oasdiff installation.");
+            
+            Directory.CreateDirectory(this._oasdiffDirectory);
 
-        var oasdiffFileName = GetOasdiffFileName();
-        var url = $"https://github.com/Tufin/oasdiff/releases/download/v{OasdiffVersion}/{oasdiffFileName}";
+            var oasdiffFileName = GetOasdiffFileName();
+            var url = $"https://github.com/Tufin/oasdiff/releases/download/v{OasdiffVersion}/{oasdiffFileName}";
 
-        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._oasdiffDirectory, oasdiffFileName), cancellationToken);
-        await this.DecompressDownloadedFileAsync(oasdiffFileName, cancellationToken);
+            await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._oasdiffDirectory, oasdiffFileName), cancellationToken);
+            await this.DecompressDownloadedFileAsync(oasdiffFileName, cancellationToken);
+            
+            this._loggerWrapper.LogMessage("Oasdiff installation completed.");
+        }
+        catch (Exception)
+        {
+            this.SkipRun = true;
+            throw;
+        }
     }
 
-    public async Task RunOasdiffAsync(IEnumerable<string> openApiSpecificationFiles, CancellationToken cancellationToken)
+    public async Task RunOasdiffAsync(IEnumerable<string> openApiSpecFiles, IEnumerable<string> generatedOpenApiSpecFiles, CancellationToken cancellationToken)
     {
-        var oasdiffExecutePath = Path.Combine(this._oasdiffDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "oasdiff.exe" : "oasdiff");
-        var reportsPath = Path.Combine(this._openApiToolsDirectory, "reports");
-        var baseSpecRelativePath = Path.GetRelativePath(this._openApiToolsDirectory, @"C:\dev\wl-openapi-msbuild\src\WebApiDebugger\openapi-v1.yaml");
-
-        foreach (var specFile in openApiSpecificationFiles)
+        if (this.SkipRun)
         {
-            var generatedSpecRelativePath = Path.GetRelativePath(this._openApiToolsDirectory, specFile);
-            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecRelativePath, generatedSpecRelativePath }, cancellationToken);
+            return;
+        }
+        
+        var generatedOpenApiSpecFilesList = generatedOpenApiSpecFiles.ToList();
+        var oasdiffExecutePath = Path.Combine(this._oasdiffDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "oasdiff.exe" : "oasdiff");
+
+        foreach (var specFile in openApiSpecFiles)
+        {
+            this._loggerWrapper.LogMessage($"Starting Oasdiff comparison with {specFile}.");
+            
+            var fileName = Path.GetFileName(specFile);
+            var baseSpecRelativePath = Path.GetRelativePath(this._openApiToolsDirectory, specFile);
+            var newSpecRelativePath = Path.GetRelativePath(this._openApiToolsDirectory, generatedOpenApiSpecFilesList.First(x => x.Contains(fileName)));
+            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecRelativePath, newSpecRelativePath, "--exclude-elements", "description,examples,title,summary", "-f", "text" }, cancellationToken);
         }
     }
 
     private async Task DecompressDownloadedFileAsync(string oasdiffFileName, CancellationToken cancellationToken)
     {
         var pathToCompressedFile = Path.Combine(this._oasdiffDirectory, oasdiffFileName);
-        await this._processWrapper.RunProcessAsync("tar", new[] { "-xzf", $"{pathToCompressedFile}", "-C", $"{this._oasdiffDirectory}" }, cancellationToken);
+        var exitCode = await this._processWrapper.RunProcessAsync("tar", new[] { "-xzf", $"{pathToCompressedFile}", "-C", $"{this._oasdiffDirectory}" }, cancellationToken);
+
+        if (exitCode != 0)
+        {
+            throw new OpenApiTaskFailedException("Failed to decompress oasdiff.");
+        }
     }
 
     private static string GetOasdiffFileName()

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace Workleap.OpenApi.MSBuild;
 
 internal sealed class OasdiffManager : IOasdiffManager
@@ -6,30 +8,45 @@ internal sealed class OasdiffManager : IOasdiffManager
 
     private readonly IHttpClientWrapper _httpClientWrapper;
     private readonly IProcessWrapper _processWrapper;
-    private readonly string _toolDirectory;
+    private readonly string _openApiToolsDirectory;
+    private readonly string _oasdiffDirectory;
 
     public OasdiffManager(IProcessWrapper processWrapper, string openApiToolsDirectoryPath, IHttpClientWrapper httpClientWrapper)
     {
         this._httpClientWrapper = httpClientWrapper;
         this._processWrapper = processWrapper;
-        this._toolDirectory = Path.Combine(openApiToolsDirectoryPath, "oasdiff", OasdiffVersion);
+        this._openApiToolsDirectory = openApiToolsDirectoryPath;
+        this._oasdiffDirectory = Path.Combine(openApiToolsDirectoryPath, "oasdiff", OasdiffVersion);
     }
-
+    
     public async Task InstallOasdiffAsync(CancellationToken cancellationToken)
     {
-        Directory.CreateDirectory(this._toolDirectory);
+        Directory.CreateDirectory(this._oasdiffDirectory);
 
         var oasdiffFileName = GetOasdiffFileName();
         var url = $"https://github.com/Tufin/oasdiff/releases/download/v{OasdiffVersion}/{oasdiffFileName}";
 
-        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._toolDirectory, oasdiffFileName), cancellationToken);
+        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, Path.Combine(this._oasdiffDirectory, oasdiffFileName), cancellationToken);
         await this.DecompressDownloadedFileAsync(oasdiffFileName, cancellationToken);
+    }
+
+    public async Task RunOasdiffAsync(IEnumerable<string> openApiSpecificationFiles, CancellationToken cancellationToken)
+    {
+        var oasdiffExecutePath = Path.Combine(this._oasdiffDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "oasdiff.exe" : "oasdiff");
+        var reportsPath = Path.Combine(this._openApiToolsDirectory, "reports");
+        var baseSpecRelativePath = Path.GetRelativePath(this._openApiToolsDirectory, @"C:\dev\wl-openapi-msbuild\src\WebApiDebugger\openapi-v1.yaml");
+
+        foreach (var specFile in openApiSpecificationFiles)
+        {
+            var generatedSpecRelativePath = Path.GetRelativePath(this._openApiToolsDirectory, specFile);
+            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecRelativePath, generatedSpecRelativePath }, cancellationToken);
+        }
     }
 
     private async Task DecompressDownloadedFileAsync(string oasdiffFileName, CancellationToken cancellationToken)
     {
-        var pathToCompressedFile = Path.Combine(this._toolDirectory, oasdiffFileName);
-        await this._processWrapper.RunProcessAsync("tar", new[] { "-xzf", $"{pathToCompressedFile}", "-C", $"{this._toolDirectory}" }, cancellationToken);
+        var pathToCompressedFile = Path.Combine(this._oasdiffDirectory, oasdiffFileName);
+        await this._processWrapper.RunProcessAsync("tar", new[] { "-xzf", $"{pathToCompressedFile}", "-C", $"{this._oasdiffDirectory}" }, cancellationToken);
     }
 
     private static string GetOasdiffFileName()

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -23,38 +23,23 @@ internal sealed class SpectralManager : ISpectralManager
     
     private string ExecutablePath { get; set; } = string.Empty;
     
-    private bool SkipRun { get; set; }
-
     public async Task InstallSpectralAsync(CancellationToken cancellationToken)
     {
-        try
-        {
-            this._loggerWrapper.LogMessage("Starting Spectral installation.");
+        this._loggerWrapper.LogMessage("Starting Spectral installation.");
             
-            Directory.CreateDirectory(this._spectralDirectory);
+        Directory.CreateDirectory(this._spectralDirectory);
 
-            this.ExecutablePath = GetSpectralFileName();
-            var url = $"https://github.com/stoplightio/spectral/releases/download/v{SpectralVersion}/{this.ExecutablePath}";
-            var destination = Path.Combine(this._spectralDirectory, this.ExecutablePath);
+        this.ExecutablePath = GetSpectralFileName();
+        var url = $"https://github.com/stoplightio/spectral/releases/download/v{SpectralVersion}/{this.ExecutablePath}";
+        var destination = Path.Combine(this._spectralDirectory, this.ExecutablePath);
         
-            await this._httpClientWrapper.DownloadFileToDestinationAsync(url, destination, cancellationToken);
+        await this._httpClientWrapper.DownloadFileToDestinationAsync(url, destination, cancellationToken);
             
-            this._loggerWrapper.LogMessage("Spectral installation completed.");
-        }
-        catch (Exception)
-        {
-            this.SkipRun = true;
-            throw;
-        }
+        this._loggerWrapper.LogMessage("Spectral installation completed.");
     }
 
     public async Task RunSpectralAsync(IEnumerable<string> swaggerDocumentPaths, string rulesetUrl, CancellationToken cancellationToken)
     {
-        if (this.SkipRun)
-        {
-            return;
-        }
-
         this._loggerWrapper.LogMessage("Starting Spectral report generation.");
         
         var spectralExecutePath = Path.Combine(this._spectralDirectory, this.ExecutablePath);

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -5,6 +5,7 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class SpectralManager : ISpectralManager
 {
     private const string SpectralVersion = "6.11.0";
+    private const string SpectralDownloadUrlFormat = "https://github.com/stoplightio/spectral/releases/download/v{0}/{1}";
 
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly IHttpClientWrapper _httpClientWrapper;
@@ -30,7 +31,7 @@ internal sealed class SpectralManager : ISpectralManager
         Directory.CreateDirectory(this._spectralDirectory);
 
         this.ExecutablePath = GetSpectralFileName();
-        var url = $"https://github.com/stoplightio/spectral/releases/download/v{SpectralVersion}/{this.ExecutablePath}";
+        var url = string.Format(SpectralDownloadUrlFormat,  SpectralVersion, this.ExecutablePath);
         var destination = Path.Combine(this._spectralDirectory, this.ExecutablePath);
         
         await this._httpClientWrapper.DownloadFileToDestinationAsync(url, destination, cancellationToken);

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -10,19 +10,20 @@ internal sealed class SwaggerManager : ISwaggerManager
     private readonly string _openApiWebApiAssemblyPath;
     private readonly string _swaggerDirectory;
     private readonly string _openApiToolsDirectoryPath;
+    private readonly string _swaggerExecutablePath;
 
-    public SwaggerManager(IProcessWrapper processWrapper, ILoggerWrapper loggerWrapper, string openApiToolsDirectoryPath, string openApiWebApiAssemblyPath)
+    public SwaggerManager(ILoggerWrapper loggerWrapper, IProcessWrapper processWrapper, string openApiToolsDirectoryPath, string openApiWebApiAssemblyPath)
     {
         this._processWrapper = processWrapper;
         this._loggerWrapper = loggerWrapper;
         this._openApiWebApiAssemblyPath = openApiWebApiAssemblyPath;
         this._openApiToolsDirectoryPath = openApiToolsDirectoryPath;
         this._swaggerDirectory = Path.Combine(openApiToolsDirectoryPath, "swagger", SwaggerVersion);
+        this._swaggerExecutablePath = Path.Combine(this._swaggerDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "swagger.exe" : "swagger");
     }
 
     public async Task<IEnumerable<string>> RunSwaggerAsync(string[] openApiSwaggerDocumentNames, CancellationToken cancellationToken)
     {
-        var swaggerExePath = Path.Combine(this._swaggerDirectory, RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "swagger.exe" : "swagger");
         var taskList = new List<Task<string>>();
 
         foreach (var documentName in openApiSwaggerDocumentNames)
@@ -31,7 +32,7 @@ internal sealed class SwaggerManager : ISwaggerManager
 
             var outputOpenApiSpecPath = Path.Combine(this._openApiToolsDirectoryPath, outputOpenApiSpecName);
 
-            taskList.Add(this.GenerateOpenApiSpecAsync(swaggerExePath, outputOpenApiSpecPath, documentName, cancellationToken));
+            taskList.Add(this.GenerateOpenApiSpecAsync(this._swaggerExecutablePath, outputOpenApiSpecPath, documentName, cancellationToken));
         }
 
         return await Task.WhenAll(taskList);
@@ -39,6 +40,11 @@ internal sealed class SwaggerManager : ISwaggerManager
 
     public async Task InstallSwaggerCliAsync(CancellationToken cancellationToken)
     {
+        if (File.Exists(this._swaggerExecutablePath))
+        {
+            return;
+        }
+        
         var retryCount = 0;
         while (retryCount < 2)
         {

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -61,7 +61,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
             await installOasdiffTask;
 
             var generateOpenApiDocsPath = (await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken)).ToList();
-            var runSpectralTask = spectralManager.RunSpectralAsync(generateOpenApiDocsPath, this.OpenApiSpectralRulesetUrl, cancellationToken);
+            var runSpectralTask = spectralManager.RunSpectralAsync(this.OpenApiSpecificationFiles, this.OpenApiSpectralRulesetUrl, cancellationToken);
             var runOasdiffTask = oasdiffManager.RunOasdiffAsync(this.OpenApiSpecificationFiles, generateOpenApiDocsPath, cancellationToken);
 
             await runSpectralTask;

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -52,13 +52,20 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
         {
             await this.GeneratePublicNugetSource();
 
-            await swaggerManager.InstallSwaggerCliAsync(cancellationToken);
-            await spectralManager.InstallSpectralAsync(cancellationToken);
-            await oasdiffManager.InstallOasdiffAsync(cancellationToken);
+            var installSwaggerCliTask = swaggerManager.InstallSwaggerCliAsync(cancellationToken);
+            var installSpectralTask = spectralManager.InstallSpectralAsync(cancellationToken);
+            var installOasdiffTask = oasdiffManager.InstallOasdiffAsync(cancellationToken);
+            
+            await installSwaggerCliTask;
+            await installSpectralTask;
+            await installOasdiffTask;
 
             var generateOpenApiDocsPath = (await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken)).ToList();
-            await spectralManager.RunSpectralAsync(generateOpenApiDocsPath, this.OpenApiSpectralRulesetUrl, cancellationToken);
-            await oasdiffManager.RunOasdiffAsync(this.OpenApiSpecificationFiles, generateOpenApiDocsPath, cancellationToken);
+            var runSpectralTask = spectralManager.RunSpectralAsync(generateOpenApiDocsPath, this.OpenApiSpectralRulesetUrl, cancellationToken);
+            var runOasdiffTask = oasdiffManager.RunOasdiffAsync(this.OpenApiSpecificationFiles, generateOpenApiDocsPath, cancellationToken);
+
+            await runSpectralTask;
+            await runOasdiffTask;
         }
         catch (OpenApiTaskFailedException e)
         {

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -43,7 +43,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
 
         if (this.OpenApiSpecificationFiles.Length != this.OpenApiSwaggerDocumentNames.Length)
         {
-            this.Log.LogWarning("You must provide the same amount of open api specification file names and swagger document file names");
+            this.Log.LogWarning("You must provide the same amount of open api specification file names and swagger document file names.");
 
             return false;
         }

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -28,12 +28,12 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
     {
         var loggerWrapper = new LoggerWrapper(this.Log);
         var processWrapper = new ProcessWrapper(this.OpenApiToolsDirectoryPath);
-        var swaggerManager = new SwaggerManager(processWrapper, loggerWrapper, this.OpenApiToolsDirectoryPath, this.OpenApiWebApiAssemblyPath);
+        var swaggerManager = new SwaggerManager(loggerWrapper, processWrapper, this.OpenApiToolsDirectoryPath, this.OpenApiWebApiAssemblyPath);
 
         using var httpClientWrapper = new HttpClientWrapper();
 
-        var spectralManager = new SpectralManager(loggerWrapper, this.OpenApiToolsDirectoryPath, httpClientWrapper, processWrapper);
-        var oasdiffManager = new OasdiffManager(processWrapper, this.OpenApiToolsDirectoryPath, httpClientWrapper);
+        var spectralManager = new SpectralManager(loggerWrapper, processWrapper, this.OpenApiToolsDirectoryPath, httpClientWrapper);
+        var oasdiffManager = new OasdiffManager(loggerWrapper, processWrapper, this.OpenApiToolsDirectoryPath, httpClientWrapper);
 
         this.Log.LogMessage(MessageImportance.Low, "{0} = '{1}'", nameof(this.OpenApiWebApiAssemblyPath), this.OpenApiWebApiAssemblyPath);
         this.Log.LogMessage(MessageImportance.Low, "{0} = '{1}'", nameof(this.OpenApiToolsDirectoryPath), this.OpenApiToolsDirectoryPath);
@@ -58,7 +58,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
 
             var generateOpenApiDocsPath = (await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken)).ToList();
             await spectralManager.RunSpectralAsync(generateOpenApiDocsPath, this.OpenApiSpectralRulesetUrl, cancellationToken);
-            await oasdiffManager.RunOasdiffAsync(generateOpenApiDocsPath, cancellationToken);
+            await oasdiffManager.RunOasdiffAsync(this.OpenApiSpecificationFiles, generateOpenApiDocsPath, cancellationToken);
         }
         catch (OpenApiTaskFailedException e)
         {

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -56,8 +56,9 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
             await spectralManager.InstallSpectralAsync(cancellationToken);
             await oasdiffManager.InstallOasdiffAsync(cancellationToken);
 
-            var swaggerDocPaths = await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken);
-            await spectralManager.RunSpectralAsync(swaggerDocPaths, this.OpenApiSpectralRulesetUrl, cancellationToken);
+            var generateOpenApiDocsPath = (await swaggerManager.RunSwaggerAsync(this.OpenApiSwaggerDocumentNames, cancellationToken)).ToList();
+            await spectralManager.RunSpectralAsync(generateOpenApiDocsPath, this.OpenApiSpectralRulesetUrl, cancellationToken);
+            await oasdiffManager.RunOasdiffAsync(generateOpenApiDocsPath, cancellationToken);
         }
         catch (OpenApiTaskFailedException e)
         {

--- a/src/Workleap.OpenApi.MSBuild/Workleap.OpenApi.MSBuild.csproj
+++ b/src/Workleap.OpenApi.MSBuild/Workleap.OpenApi.MSBuild.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageReadmeFile>README.md</PackageReadmeFile>
 

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -10,7 +10,7 @@
   <UsingTask Condition="'$(OpenApiDebuggingEnabled)' != 'true'" TaskName="$(MSBuildThisFileName).ValidateOpenApiTask" AssemblyFile="$(MSBuildThisFileDirectory)task\$(MSBuildThisFileName).dll" />
 
   <!-- This is the location of this task assembly when debugging the task in an IDE -->
-  <UsingTask Condition="'$(OpenApiDebuggingEnabled)' == 'true'" TaskName="$(MSBuildThisFileName).ValidateOpenApiTask" AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\netstandard2.0\$(MSBuildThisFileName).dll" />
+  <UsingTask Condition="'$(OpenApiDebuggingEnabled)' == 'true'" TaskName="$(MSBuildThisFileName).ValidateOpenApiTask" AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\netstandard2.1\$(MSBuildThisFileName).dll" />
 
   <!-- We can only analyze the OpenAPI spec after the project has been built -->
   <Target Name="ValidateOpenApi" DependsOnTargets="ResolveProjectReferences" AfterTargets="Build">


### PR DESCRIPTION
## Changes
___
- Updated project to `.net standard 2.1` in order to support `Oasdiff`
- Implemented Oasdiff run on build
- Added checks to skip run if tools are not installed correctly
- Added optional installation for `dotnet tool` when the correct file already exists
- General refactoring with logs and parameters