### PR TITLE
Addressed spectral warn not fail on CI and updated oasdiff

### DIFF
--- a/src/WebApiDebugger/Controllers/WeatherForecastController.cs
+++ b/src/WebApiDebugger/Controllers/WeatherForecastController.cs
@@ -4,6 +4,7 @@ namespace WebApiDebugger.Controllers;
 
 [ApiController]
 [Route("[controller]")]
+[Produces("application/json")]
 public class WeatherForecastController : ControllerBase
 {
     private static readonly string[] Summaries = new[]

--- a/src/Workleap.OpenApi.MSBuild/ILoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/ILoggerWrapper.cs
@@ -1,4 +1,4 @@
-using Microsoft.Build.Utilities;
+using Microsoft.Build.Framework;
 
 namespace Workleap.OpenApi.MSBuild;
 
@@ -6,5 +6,5 @@ public interface ILoggerWrapper
 {
     void LogWarning(string message, params object[] messageArgs);
 
-    void LogMessage(string message, params object[] messageArgs);
+    void LogMessage(string message, MessageImportance importance = MessageImportance.Low, params object[] messageArgs);
 }

--- a/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
@@ -1,3 +1,4 @@
+using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
 namespace Workleap.OpenApi.MSBuild;
@@ -11,6 +12,6 @@ internal sealed class LoggerWrapper : ILoggerWrapper
     public void LogWarning(string message, params object[] messageArgs)
         => this._taskLoggingHelper.LogWarning(message, messageArgs);
 
-    public void LogMessage(string message, params object[] messageArgs)
-        => this._taskLoggingHelper.LogMessage(message, messageArgs);
+    public void LogMessage(string message, MessageImportance importance = MessageImportance.Low, params object[] messageArgs)
+        => this._taskLoggingHelper.LogMessage(importance, message, messageArgs);
 }

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -45,8 +45,15 @@ internal sealed class OasdiffManager : IOasdiffManager
             this._loggerWrapper.LogMessage($"Starting Oasdiff comparison with {baseSpecFile}.");
             
             var fileName = Path.GetFileName(baseSpecFile);
-            var newSpecRelativePath = generatedOpenApiSpecFilesList.First(x => x.Contains(fileName));
-            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, newSpecRelativePath, "--exclude-elements", "description,examples,title,summary", "-f", "text", "-o" }, cancellationToken);
+            var generatedSpecFilePath = generatedOpenApiSpecFilesList.FirstOrDefault(x => x.Contains(fileName));
+            
+            if (generatedSpecFilePath == null)
+            {
+                this._loggerWrapper.LogWarning($"Could not find a generated spec file for {baseSpecFile}.");
+                continue;
+            }
+            
+            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, generatedSpecFilePath, "--exclude-elements", "description,examples,title,summary", "-f", "text", "-o" }, cancellationToken);
         }
     }
 

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -55,7 +55,7 @@ internal sealed class OasdiffManager : IOasdiffManager
             }
             
             await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, generatedSpecFilePath, "--exclude-elements", "description,examples,title,summary", "-f", "text", "-o" }, cancellationToken);
-            this._loggerWrapper.LogMessage($"\n ******** Oasdiff: Diff comparison completed ********", MessageImportance.High);
+            this._loggerWrapper.LogMessage($"\n ****************************************************************", MessageImportance.High);
         }
     }
 

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -46,7 +46,7 @@ internal sealed class OasdiffManager : IOasdiffManager
             
             var fileName = Path.GetFileName(baseSpecFile);
             var newSpecRelativePath = generatedOpenApiSpecFilesList.First(x => x.Contains(fileName));
-            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, newSpecRelativePath, "--exclude-elements", "description,examples,title,summary", "-f", "text" }, cancellationToken);
+            await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, newSpecRelativePath, "--exclude-elements", "description,examples,title,summary", "-f", "text", "-o" }, cancellationToken);
         }
     }
 
@@ -59,7 +59,7 @@ internal sealed class OasdiffManager : IOasdiffManager
             return;
         }
         
-        var exitCode = await this._processWrapper.RunProcessAsync("tar", new[] { "-xzf", $"{pathToCompressedFile}", "-C", $"{this._oasdiffDirectory}" }, cancellationToken: cancellationToken);
+        var exitCode = await this._processWrapper.RunProcessAsync("tar", new[] { "-xzf", $"{pathToCompressedFile}", "-C", $"{this._oasdiffDirectory}" }, cancellationToken);
 
         if (exitCode != 0)
         {

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
 
 namespace Workleap.OpenApi.MSBuild;
 
@@ -42,7 +43,7 @@ internal sealed class OasdiffManager : IOasdiffManager
 
         foreach (var baseSpecFile in openApiSpecFiles)
         {
-            this._loggerWrapper.LogMessage($"Starting Oasdiff comparison with {baseSpecFile}.");
+            this._loggerWrapper.LogMessage($"Starting Oasdiff comparison with {baseSpecFile}.", MessageImportance.High);
             
             var fileName = Path.GetFileName(baseSpecFile);
             var generatedSpecFilePath = generatedOpenApiSpecFilesList.FirstOrDefault(x => x.Contains(fileName));

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -43,7 +43,7 @@ internal sealed class OasdiffManager : IOasdiffManager
 
         foreach (var baseSpecFile in openApiSpecFiles)
         {
-            this._loggerWrapper.LogMessage($"Starting Oasdiff comparison with {baseSpecFile}.", MessageImportance.High);
+            this._loggerWrapper.LogMessage($"\n Starting Oasdiff comparison with {baseSpecFile}.", MessageImportance.High);
             
             var fileName = Path.GetFileName(baseSpecFile);
             var generatedSpecFilePath = generatedOpenApiSpecFilesList.FirstOrDefault(x => x.Contains(fileName));

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -43,7 +43,7 @@ internal sealed class OasdiffManager : IOasdiffManager
 
         foreach (var baseSpecFile in openApiSpecFiles)
         {
-            this._loggerWrapper.LogMessage($"\n Starting Oasdiff comparison with {baseSpecFile}.", MessageImportance.High);
+            this._loggerWrapper.LogMessage($"\n ******** Oasdiff: Diff comparison with {baseSpecFile} ********", MessageImportance.High);
             
             var fileName = Path.GetFileName(baseSpecFile);
             var generatedSpecFilePath = generatedOpenApiSpecFilesList.FirstOrDefault(x => x.Contains(fileName));
@@ -55,6 +55,7 @@ internal sealed class OasdiffManager : IOasdiffManager
             }
             
             await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, generatedSpecFilePath, "--exclude-elements", "description,examples,title,summary", "-f", "text", "-o" }, cancellationToken);
+            this._loggerWrapper.LogMessage($"\n ******** Oasdiff: Diff comparison completed ********", MessageImportance.High);
         }
     }
 

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -84,7 +84,7 @@ internal sealed class SpectralManager : ISpectralManager
             await this.AssignExecutePermission(spectralExecutePath, cancellationToken);
         }
 
-        var exitCode = await this._processWrapper.RunProcessAsync(spectralExecutePath, new[] { "lint", swaggerDocumentPath, "--ruleset", rulesetUrl, "--format", "html", "--format", "pretty", "--output.html", htmlReportPath, "--fail-severity=warn" }, cancellationToken: cancellationToken);
+        var exitCode = await this._processWrapper.RunProcessAsync(spectralExecutePath, new[] { "lint", swaggerDocumentPath, "--ruleset", rulesetUrl, "--format", "html", "--format", "pretty", "--output.html", htmlReportPath, "--fail-severity=warn" }, cancellationToken);
         if (exitCode != 0)
         {
             throw new OpenApiTaskFailedException($"Spectral report for {swaggerDocumentPath} could not be created.");
@@ -95,7 +95,7 @@ internal sealed class SpectralManager : ISpectralManager
 
     private async Task AssignExecutePermission(string spectralExecutePath, CancellationToken cancellationToken)
     {
-        var chmodExitCode = await this._processWrapper.RunProcessAsync("chmod", new[] { "+x",  spectralExecutePath }, cancellationToken: cancellationToken);
+        var chmodExitCode = await this._processWrapper.RunProcessAsync("chmod", new[] { "+x",  spectralExecutePath }, cancellationToken);
         if (chmodExitCode != 0)
         {
             throw new OpenApiTaskFailedException($"Failed to provide execute permission to {spectralExecutePath}");

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -53,7 +53,7 @@ internal sealed class SpectralManager : ISpectralManager
             
             this._loggerWrapper.LogMessage("\n ******** Spectral: Validating {0} against ruleset ********", MessageImportance.High, documentPath);
             await this.GenerateSpectralReport(spectralExecutePath, documentPath, rulesetUrl, Path.Combine(this._openApiReportsDirectoryPath, outputSpectralReportName), cancellationToken);
-            this._loggerWrapper.LogMessage("\n ******** Spectral: Validation complete ********", MessageImportance.High, documentPath);
+            this._loggerWrapper.LogMessage("\n *********************************************************", MessageImportance.High, documentPath);
         }
     }
 

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -51,8 +51,9 @@ internal sealed class SpectralManager : ISpectralManager
             var documentName = Path.GetFileNameWithoutExtension(documentPath);
             var outputSpectralReportName = $"spectral-{documentName}.html";
             
-            this._loggerWrapper.LogMessage("\n Validating {0} against Spectral ruleset", MessageImportance.High, documentPath);
+            this._loggerWrapper.LogMessage("\n ******** Spectral: Validating {0} against ruleset ********", MessageImportance.High, documentPath);
             await this.GenerateSpectralReport(spectralExecutePath, documentPath, rulesetUrl, Path.Combine(this._openApiReportsDirectoryPath, outputSpectralReportName), cancellationToken);
+            this._loggerWrapper.LogMessage("\n ******** Spectral: Validation complete ********", MessageImportance.High, documentPath);
         }
     }
 

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -51,7 +51,7 @@ internal sealed class SpectralManager : ISpectralManager
             var documentName = Path.GetFileNameWithoutExtension(documentPath);
             var outputSpectralReportName = $"spectral-{documentName}.html";
             
-            this._loggerWrapper.LogMessage("Validating {0} against Spectral ruleset", MessageImportance.High, documentPath);
+            this._loggerWrapper.LogMessage("\n Validating {0} against Spectral ruleset", MessageImportance.High, documentPath);
             await this.GenerateSpectralReport(spectralExecutePath, documentPath, rulesetUrl, Path.Combine(this._openApiReportsDirectoryPath, outputSpectralReportName), cancellationToken);
         }
     }

--- a/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SpectralManager.cs
@@ -1,4 +1,5 @@
 using System.Runtime.InteropServices;
+using Microsoft.Build.Framework;
 
 namespace Workleap.OpenApi.MSBuild;
 
@@ -49,6 +50,8 @@ internal sealed class SpectralManager : ISpectralManager
         {
             var documentName = Path.GetFileNameWithoutExtension(documentPath);
             var outputSpectralReportName = $"spectral-{documentName}.html";
+            
+            this._loggerWrapper.LogMessage("Validating {0} against Spectral ruleset", MessageImportance.High, documentPath);
             await this.GenerateSpectralReport(spectralExecutePath, documentPath, rulesetUrl, Path.Combine(this._openApiReportsDirectoryPath, outputSpectralReportName), cancellationToken);
         }
     }
@@ -90,7 +93,7 @@ internal sealed class SpectralManager : ISpectralManager
             throw new OpenApiTaskFailedException($"Spectral report for {swaggerDocumentPath} could not be created.");
         }
 
-        this._loggerWrapper.LogMessage("Spectral report generated. {0}", htmlReportPath);
+        this._loggerWrapper.LogMessage("Spectral report generated. {0}", messageArgs: htmlReportPath);
     }
 
     private async Task AssignExecutePermission(string spectralExecutePath, CancellationToken cancellationToken)

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -48,7 +48,7 @@ internal sealed class SwaggerManager : ISwaggerManager
         var retryCount = 0;
         while (retryCount < 2)
         {
-            var exitCode = await this._processWrapper.RunProcessAsync("dotnet", new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--tool-path", this._swaggerDirectory, "--version", SwaggerVersion }, cancellationToken);
+            var exitCode = await this._processWrapper.RunProcessAsync("dotnet", new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--tool-path", this._swaggerDirectory, "--version", SwaggerVersion }, cancellationToken: cancellationToken);
 
             if (exitCode != 0 && retryCount != 1)
             {
@@ -68,7 +68,7 @@ internal sealed class SwaggerManager : ISwaggerManager
 
     public async Task<string> GenerateOpenApiSpecAsync(string swaggerExePath, string outputOpenApiSpecPath, string documentName, CancellationToken cancellationToken)
     {
-        var exitCode = await this._processWrapper.RunProcessAsync(swaggerExePath, new[] { "tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName }, cancellationToken);
+        var exitCode = await this._processWrapper.RunProcessAsync(swaggerExePath, new[] { "tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName }, cancellationToken: cancellationToken);
 
         if (exitCode != 0)
         {

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -48,7 +48,7 @@ internal sealed class SwaggerManager : ISwaggerManager
         var retryCount = 0;
         while (retryCount < 2)
         {
-            var exitCode = await this._processWrapper.RunProcessAsync("dotnet", new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--tool-path", this._swaggerDirectory, "--version", SwaggerVersion }, cancellationToken: cancellationToken);
+            var exitCode = await this._processWrapper.RunProcessAsync("dotnet", new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--tool-path", this._swaggerDirectory, "--version", SwaggerVersion }, cancellationToken);
 
             if (exitCode != 0 && retryCount != 1)
             {

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -72,12 +72,9 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
             {
                 return false;
             }
-
-            var runSpectralTask = spectralManager.RunSpectralAsync(this.OpenApiSpecificationFiles, this.OpenApiSpectralRulesetUrl, cancellationToken);
-            var runOasdiffTask = oasdiffManager.RunOasdiffAsync(this.OpenApiSpecificationFiles, generateOpenApiDocsPath, cancellationToken);
-
-            await runSpectralTask;
-            await runOasdiffTask;
+            
+            await spectralManager.RunSpectralAsync(this.OpenApiSpecificationFiles, this.OpenApiSpectralRulesetUrl, cancellationToken);
+            await oasdiffManager.RunOasdiffAsync(this.OpenApiSpecificationFiles, generateOpenApiDocsPath, cancellationToken);
         }
         catch (OpenApiTaskFailedException e)
         {

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -16,6 +16,9 @@
   <Target Name="ValidateOpenApi" DependsOnTargets="ResolveProjectReferences" AfterTargets="Build">
     <PropertyGroup>
       <!-- The path of the ASP.NET Core project being built -->
+      <StartupAssemblyPath Condition="'$(StartupAssemblyPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)</StartupAssemblyPath>
+      
+      <!-- The path of the ASP.NET Core project being built -->
       <OpenApiWebApiAssemblyPath Condition="'$(OpenApiWebApiAssemblyPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)$(AssemblyName).dll</OpenApiWebApiAssemblyPath>
 
       <!-- The base directory path where the OpenAPI tools will be downloaded -->
@@ -45,6 +48,7 @@
     </PropertyGroup>
 
     <ValidateOpenApiTask
+      StartupAssemblyPath="$(StartupAssemblyPath)"
       OpenApiWebApiAssemblyPath="$(OpenApiWebApiAssemblyPath)"
       OpenApiToolsDirectoryPath="$(OpenApiToolsDirectoryPath)"
       OpenApiSpectralRulesetUrl="$(OpenApiSpectralRulesetUrl)"

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -15,10 +15,10 @@
   <!-- We can only analyze the OpenAPI spec after the project has been built -->
   <Target Name="ValidateOpenApi" DependsOnTargets="ResolveProjectReferences" AfterTargets="Build">
     <PropertyGroup>
-      <!-- The path of the ASP.NET Core project being built -->
+      <!-- The path of the ASP.NET Core project build output directory -->
       <StartupAssemblyPath Condition="'$(StartupAssemblyPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)</StartupAssemblyPath>
       
-      <!-- The path of the ASP.NET Core project being built -->
+      <!-- The path of the ASP.NET Core project DLL being executed after built -->
       <OpenApiWebApiAssemblyPath Condition="'$(OpenApiWebApiAssemblyPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)$(AssemblyName).dll</OpenApiWebApiAssemblyPath>
 
       <!-- The base directory path where the OpenAPI tools will be downloaded -->

--- a/src/tests/WebApi.MsBuild.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest/openapi-v1.yaml
@@ -3,7 +3,7 @@ info:
   title: V1 API General
   version: v1
 paths:
-  /WeatherForecast/:
+  /WeatherForecast:
     get:
       tags:
         - WeatherForecast

--- a/src/tests/WebApi.MsBuild.SystemTest/openapi-v1.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest/openapi-v1.yaml
@@ -3,7 +3,7 @@ info:
   title: V1 API General
   version: v1
 paths:
-  /WeatherForecast:
+  /WeatherForecast/:
     get:
       tags:
         - WeatherForecast


### PR DESCRIPTION
## Changes
- Fixed bug where `appsettings.json` was not being applied when executing MSBuild task
- Updated `Oasdiff` to `1.9.6` -> This fixes relative file path issue
- Fixed `Spectral` cmd not failing on `warn` errors