### PR TITLE
IDP-818 - Handling running swashbuckle cli with a sdk greater than net7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "8.0.x"
 
       - run: ./Build.ps1
         shell: pwsh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
 
       - run: ./Build.ps1
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: "6.0.x"
+          dotnet-version: "8.0.x"
       
       - run: ./Build.ps1
         shell: pwsh

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,6 @@ jobs:
           fetch-depth: 0
 
       - uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: "8.0.x"
       
       - run: ./Build.ps1
         shell: pwsh

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "6.0.418",
+      "version": "8.0.101",
       "rollForward": "latestMinor",
       "allowPrerelease": false
     }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,11 +6,11 @@
     <PackageProjectUrl>https://github.com/gsoft-inc/wl-openapi-msbuild</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <LangVersion>10</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Description>TODO.</Description>
-    <AnalysisLevel>6.0-all</AnalysisLevel>
+    <AnalysisLevel>8.0-all</AnalysisLevel>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -14,7 +14,6 @@
   <PropertyGroup>
     <OpenApiDebuggingEnabled>true</OpenApiDebuggingEnabled>
     <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
-    <OpenApiCompareCodeAgainstSpecFile Condition="'$(Configuration)' == 'Release'">true</OpenApiCompareCodeAgainstSpecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
@@ -13,6 +13,8 @@
 
   <PropertyGroup>
     <OpenApiDebuggingEnabled>true</OpenApiDebuggingEnabled>
+    <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+    <OpenApiCompareCodeAgainstSpecFile Condition="'$(Configuration)' == 'Release'">true</OpenApiCompareCodeAgainstSpecFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Workleap.OpenApi.MSBuild.Tests/Workleap.OpenApi.MSBuild.Tests.csproj
+++ b/src/Workleap.OpenApi.MSBuild.Tests/Workleap.OpenApi.MSBuild.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/src/Workleap.OpenApi.MSBuild/ILoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/ILoggerWrapper.cs
@@ -2,7 +2,7 @@ using Microsoft.Build.Framework;
 
 namespace Workleap.OpenApi.MSBuild;
 
-public interface ILoggerWrapper
+internal interface ILoggerWrapper
 {
     void LogWarning(string message, params object[] messageArgs);
 

--- a/src/Workleap.OpenApi.MSBuild/IProcessWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/IProcessWrapper.cs
@@ -2,7 +2,7 @@ using CliWrap.Buffered;
 
 namespace Workleap.OpenApi.MSBuild;
 
-public interface IProcessWrapper
+internal interface IProcessWrapper
 {
     public Task<BufferedCommandResult> RunProcessAsync(string filename, string[] arguments, CancellationToken cancellationToken, Dictionary<string, string?>? envVars = null);
 }

--- a/src/Workleap.OpenApi.MSBuild/IProcessWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/IProcessWrapper.cs
@@ -4,5 +4,5 @@ namespace Workleap.OpenApi.MSBuild;
 
 public interface IProcessWrapper
 {
-    public Task<BufferedCommandResult> RunProcessAsync(string filename, string[] arguments, CancellationToken cancellationToken);
+    public Task<BufferedCommandResult> RunProcessAsync(string filename, string[] arguments, CancellationToken cancellationToken, Dictionary<string, string?>? envVars = null);
 }

--- a/src/Workleap.OpenApi.MSBuild/ISpectralManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/ISpectralManager.cs
@@ -1,6 +1,6 @@
 namespace Workleap.OpenApi.MSBuild;
 
-public interface ISpectralManager
+internal interface ISpectralManager
 {
     public Task InstallSpectralAsync(CancellationToken cancellationToken);
 

--- a/src/Workleap.OpenApi.MSBuild/ISwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/ISwaggerManager.cs
@@ -1,6 +1,6 @@
 namespace Workleap.OpenApi.MSBuild;
 
-public interface ISwaggerManager
+internal interface ISwaggerManager
 {
     Task<IEnumerable<string>> RunSwaggerAsync(string[] openApiSwaggerDocumentNames, CancellationToken cancellationToken);
 

--- a/src/Workleap.OpenApi.MSBuild/ProcessWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/ProcessWrapper.cs
@@ -6,7 +6,7 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class ProcessWrapper : IProcessWrapper
 {
     private readonly string _workingDirectory;
-    private static readonly Dictionary<string, string?> _defaultEnvVars = new();
+    private static readonly Dictionary<string, string?> DefaultEnvVars = new();
 
     public ProcessWrapper(string workingDirectory)
     {
@@ -19,7 +19,7 @@ internal sealed class ProcessWrapper : IProcessWrapper
             .WithWorkingDirectory(this._workingDirectory)
             .WithValidation(CommandResultValidation.None)
             .WithArguments(arguments)
-            .WithEnvironmentVariables(envVars ?? this._defaultEnvVars)
+            .WithEnvironmentVariables(envVars ?? DefaultEnvVars)
             .ExecuteBufferedAsync(cancellationToken);
 
         return result;

--- a/src/Workleap.OpenApi.MSBuild/ProcessWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/ProcessWrapper.cs
@@ -6,18 +6,20 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class ProcessWrapper : IProcessWrapper
 {
     private readonly string _workingDirectory;
+    private readonly Dictionary<string, string?> _defaultEnvVars = new();
 
     public ProcessWrapper(string workingDirectory)
     {
         this._workingDirectory = workingDirectory;
     }
 
-    public async Task<BufferedCommandResult> RunProcessAsync(string filename, string[] arguments, CancellationToken cancellationToken)
+    public async Task<BufferedCommandResult> RunProcessAsync(string filename, string[] arguments, CancellationToken cancellationToken, Dictionary<string, string?>? envVars = null)
     {
         var result = await Cli.Wrap(filename)
             .WithWorkingDirectory(this._workingDirectory)
             .WithValidation(CommandResultValidation.None)
             .WithArguments(arguments)
+            .WithEnvironmentVariables(envVars ?? this._defaultEnvVars)
             .ExecuteBufferedAsync(cancellationToken);
 
         return result;

--- a/src/Workleap.OpenApi.MSBuild/ProcessWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/ProcessWrapper.cs
@@ -6,7 +6,7 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class ProcessWrapper : IProcessWrapper
 {
     private readonly string _workingDirectory;
-    private readonly Dictionary<string, string?> _defaultEnvVars = new();
+    private static readonly Dictionary<string, string?> _defaultEnvVars = new();
 
     public ProcessWrapper(string workingDirectory)
     {

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -51,7 +51,7 @@ internal sealed class SwaggerManager : ISwaggerManager
         {
             var result = await this._processWrapper.RunProcessAsync(
                 "dotnet",
-                new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--ignore-failed-sources", "--tool-path", this._swaggerDirectory, "--configfile", Path.Combine(this._openApiToolsDirectoryPath, "nuget.config"), "--version", SwaggerVersion },
+                ["tool", "update", "Swashbuckle.AspNetCore.Cli", "--ignore-failed-sources", "--tool-path", this._swaggerDirectory, "--configfile", Path.Combine(this._openApiToolsDirectoryPath, "nuget.config"), "--version", SwaggerVersion],
                 cancellationToken);
 
             if (result.ExitCode != 0 && retryCount != 1)

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -75,7 +75,8 @@ internal sealed class SwaggerManager : ISwaggerManager
 
     public async Task<string> GenerateOpenApiSpecAsync(string swaggerExePath, string outputOpenApiSpecPath, string documentName, CancellationToken cancellationToken)
     {
-        var result = await this._processWrapper.RunProcessAsync(swaggerExePath, new[] { "tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName }, cancellationToken: cancellationToken, envVars: new Dictionary<string, string?>() { { "DOTNET_ROLL_FORWARD", "LatestMajor" } });
+        var envVars = new Dictionary<string, string?>() { { "DOTNET_ROLL_FORWARD", "LatestMajor" } };
+        var result = await this._processWrapper.RunProcessAsync(swaggerExePath, new[] { "tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName }, cancellationToken: cancellationToken, envVars: envVars);
         this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
 
         if (result.ExitCode != 0)

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -45,11 +45,14 @@ internal sealed class SwaggerManager : ISwaggerManager
         {
             return;
         }
-        
+
         var retryCount = 0;
         while (retryCount < 2)
         {
-            var result = await this._processWrapper.RunProcessAsync("dotnet", new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--ignore-failed-sources", "--tool-path", this._swaggerDirectory, "--configfile", Path.Combine(this._openApiToolsDirectoryPath, "nuget.config"), "--version", SwaggerVersion }, cancellationToken);
+            var result = await this._processWrapper.RunProcessAsync(
+                "dotnet",
+                new[] { "tool", "update", "Swashbuckle.AspNetCore.Cli", "--ignore-failed-sources", "--tool-path", this._swaggerDirectory, "--configfile", Path.Combine(this._openApiToolsDirectoryPath, "nuget.config"), "--version", SwaggerVersion },
+                cancellationToken);
 
             if (result.ExitCode != 0 && retryCount != 1)
             {
@@ -72,7 +75,7 @@ internal sealed class SwaggerManager : ISwaggerManager
 
     public async Task<string> GenerateOpenApiSpecAsync(string swaggerExePath, string outputOpenApiSpecPath, string documentName, CancellationToken cancellationToken)
     {
-        var result = await this._processWrapper.RunProcessAsync(swaggerExePath, new[] { "tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName }, cancellationToken: cancellationToken);
+        var result = await this._processWrapper.RunProcessAsync(swaggerExePath, new[] { "tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName }, cancellationToken: cancellationToken, envVars: new Dictionary<string, string?>() { { "DOTNET_ROLL_FORWARD", "LatestMajor" } });
         this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
 
         if (result.ExitCode != 0)

--- a/src/tests/WebApi.MsBuild.SystemTest.CodeFirst/WebApi.MsBuild.SystemTest.CodeFirst.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.CodeFirst/WebApi.MsBuild.SystemTest.CodeFirst.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>
@@ -17,5 +16,4 @@
     <ItemGroup>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     </ItemGroup>
-
 </Project>

--- a/src/tests/WebApi.MsBuild.SystemTest.ContractFirst/WebApi.MsBuild.SystemTest.ContractFirst.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.ContractFirst/WebApi.MsBuild.SystemTest.ContractFirst.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <IsPackable>false</IsPackable>


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
So Swashbuckle.AspNetCore.Cli targeted max framework .net7 for now. That created a problem when our task was used in a project tageting .net8 since only the .net8 runtime would be available and you would get an error.

So I modified the ProcessManager to be able to receive environment variables that will be passed to CliWrap and in the SwaggerManager we now tell the process running the swashbuckle cli to roll over to the latest major available.

I also upgraded our debuggerWebapi to target .net8, proof that the fix works.


## Breaking changes
No

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
