### PR TITLE
[IDP-869] Add an option to disable the `ValidateOpenApi` target

### DIFF
--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+    <OpenApiEnabled>true</OpenApiEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <OpenApiEnabled Condition="'$(OpenApiEnabled)' == ''">true</OpenApiEnabled>
+    
     <!-- We use this property when developing this MSBuild task in an IDE, -->
     <!-- so we can reference the task assembly that is built in its bin folder instead of the one in the distributed NuGet package -->
-    <OpenApiDebuggingEnabled Condition="'$(OpenApiDebuggingEnabled)' == ''">false</OpenApiDebuggingEnabled>
+    <OpenApiDebuggingEnabled Condition="'$(OpenApiDebuggingEnabled)' == ''">false</OpenApiDebuggingEnabled>    
   </PropertyGroup>
 
   <!-- This is the location of this task assembly when it is distributed as a NuGet package -->
@@ -13,7 +15,7 @@
   <UsingTask Condition="'$(OpenApiDebuggingEnabled)' == 'true'" TaskName="$(MSBuildThisFileName).ValidateOpenApiTask" AssemblyFile="$(MSBuildThisFileDirectory)..\..\bin\$(Configuration)\netstandard2.0\$(MSBuildThisFileName).dll" />
 
   <!-- We can only analyze the OpenAPI spec after the project has been built -->
-  <Target Name="ValidateOpenApi" DependsOnTargets="ResolveProjectReferences" AfterTargets="Build">
+  <Target Name="ValidateOpenApi" DependsOnTargets="ResolveProjectReferences" AfterTargets="Build" Condition="'$(OpenApiEnabled)' == 'true'">
     <PropertyGroup>
       <!-- Set development mode: ContractFirst or CodeFirst -->
       <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">ContractFirst</OpenApiDevelopmentMode>


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->

- Add the `OpenApiEnabled` option to disable the `ValidateOpenApi` target

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
