### PR TITLE
[IDP-869] Fix `StartupAssemblyPath` when the `OutputPath` is absolute

### DIFF
--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -22,13 +22,13 @@
       <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == ''">false</OpenApiCompareCodeAgainstSpecFile>
       
       <!-- The path of the ASP.NET Core project build output directory -->
-      <StartupAssemblyPath Condition="'$(StartupAssemblyPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)</StartupAssemblyPath>
+      <StartupAssemblyPath Condition="'$(StartupAssemblyPath)' == ''">$([System.IO.Path]::Combine($(MSBuildProjectDirectory), $(OutputPath)))\</StartupAssemblyPath>
       
       <!-- The path of the ASP.NET Core project DLL being executed after built -->
-      <OpenApiWebApiAssemblyPath Condition="'$(OpenApiWebApiAssemblyPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)$(AssemblyName).dll</OpenApiWebApiAssemblyPath>
+      <OpenApiWebApiAssemblyPath Condition="'$(OpenApiWebApiAssemblyPath)' == ''">$(StartupAssemblyPath)$(AssemblyName).dll</OpenApiWebApiAssemblyPath>
 
       <!-- The base directory path where the OpenAPI tools will be downloaded -->
-      <OpenApiToolsDirectoryPath Condition="'$(OpenApiToolsDirectoryPath)' == ''">$(MSBuildProjectDirectory)\$(OutputPath)openapi</OpenApiToolsDirectoryPath>
+      <OpenApiToolsDirectoryPath Condition="'$(OpenApiToolsDirectoryPath)' == ''">$(StartupAssemblyPath)openapi</OpenApiToolsDirectoryPath>
 
       <!-- The URL of the OpenAPI Spectral ruleset to validate against -->
       <OpenApiSpectralRulesetUrl Condition="'$(OpenApiSpectralRulesetUrl)' == ''">https://raw.githubusercontent.com/gsoft-inc/wl-api-guidelines/0.1.0/.spectral.yaml</OpenApiSpectralRulesetUrl>


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
<!-- What was changed in this pull request? -->

Combine path using Path.Combine instead of concatening strings.

## Breaking changes
<!-- What breaking changes were added (if any) and how are they addressed? -->

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
