### PR TITLE
Feature/idp 1028 treat warning as error flag

### DIFF
--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -50,8 +50,8 @@ Process {
         BuildProject -openApiMsBuildSource $outputDir -projectPath $codeFirstSysTestDir -isFailureExpected $false
         BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $true
-        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=true"
-        BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=true"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=false"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=false"
     }
     finally {
         Pop-Location

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -5,6 +5,26 @@ Begin {
 }
 
 Process {
+    function BuildProject {
+        param (
+            [string]$openApiMsBuildSource,
+            [string]$projectPath,
+            [bool]$isFailureExpected,
+            [string]$extraArgs
+        )
+        Push-Location $projectPath
+        
+        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $openApiMsBuildSource }
+
+        $buildProcess = Start-Process -FilePath "dotnet" -ArgumentList "build -c Release $extraArgs" -NoNewWindow -PassThru -Wait
+
+        if ($isFailureExpected -and $buildProcess.ExitCode -eq 0 ) {
+            Write-Error "The build did not fail as expected for project $projectPath."
+        } elseif (!$isFailureExpected -and $buildProcess.ExitCode -ne 0) {
+            Write-Error "The build unexpectedly failed for project $projectPath."
+        }
+    }
+
     function Exec([scriptblock]$Command) {
         & $Command
         if ($LASTEXITCODE -ne 0) {
@@ -14,6 +34,7 @@ Process {
     
     $workingDir = Join-Path $PSScriptRoot "src"
     $outputDir = Join-Path $PSScriptRoot ".output"
+    
     $contractFirstSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.ContractFirst"
     $codeFirstSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.CodeFirst"
     $oasDiffErrorSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.OasDiffError"
@@ -22,28 +43,15 @@ Process {
     try {
         Push-Location $workingDir
 
+        # Build the OpenApi.MSBuild package to be used in the system tests
         Exec { & dotnet pack -c Release -o "$outputDir" }
 
-        Push-Location $contractFirstSysTestDir
-        
-        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
-        Exec { & dotnet build -c Release }
-        
-        Push-Location $codeFirstSysTestDir
-        
-        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
-        Exec { & dotnet build -c Release }
-
-        Push-Location $oasDiffErrorSysTestDir
-        
-        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
-        Exec { & dotnet build -c Release }
-        
-        Push-Location $spectralErrorSysTestDir
-        
-        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
-        Exec { & dotnet build -c Release }
-
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $contractFirstSysTestDir -isFailureExpected $false
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $codeFirstSysTestDir -isFailureExpected $false
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $true
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
     }
     finally {
         Pop-Location

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -16,6 +16,8 @@ Process {
     $outputDir = Join-Path $PSScriptRoot ".output"
     $contractFirstSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.ContractFirst"
     $codeFirstSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.CodeFirst"
+    $oasDiffErrorSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.OasDiffError"
+    $spectralErrorSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.SpectralError"
 
     try {
         Push-Location $workingDir
@@ -25,12 +27,22 @@ Process {
         Push-Location $contractFirstSysTestDir
         
         Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
-        Exec { & dotnet build -c Release -warnaserror }
+        Exec { & dotnet build -c Release }
         
         Push-Location $codeFirstSysTestDir
         
         Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
-        Exec { & dotnet build -c Release -warnaserror }
+        Exec { & dotnet build -c Release }
+
+        Push-Location $oasDiffErrorSysTestDir
+        
+        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
+        Exec { & dotnet build -c Release }
+        
+        Push-Location $spectralErrorSysTestDir
+        
+        Exec { & dotnet add package Workleap.OpenApi.MSBuild --prerelease --source $outputDir }
+        Exec { & dotnet build -c Release }
 
     }
     finally {

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -50,7 +50,7 @@ Process {
         BuildProject -openApiMsBuildSource $outputDir -projectPath $codeFirstSysTestDir -isFailureExpected $false
         BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $true
-        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true -extraArgs "/p:OpenApiIgnoreErrors=true"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
     }
     finally {

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -50,7 +50,7 @@ Process {
         BuildProject -openApiMsBuildSource $outputDir -projectPath $codeFirstSysTestDir -isFailureExpected $false
         BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $true
-        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true -extraArgs "/p:OpenApiIgnoreErrors=true"
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
     }
     finally {

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -19,9 +19,9 @@ Process {
         $buildProcess = Start-Process -FilePath "dotnet" -ArgumentList "build -c Release $extraArgs" -NoNewWindow -PassThru -Wait
 
         if ($isFailureExpected -and $buildProcess.ExitCode -eq 0 ) {
-            Write-Error "The build did not fail as expected for project $projectPath."
+            Write-Error "The build for project $projectPath was expected to fail, but it succeeded."
         } elseif (!$isFailureExpected -and $buildProcess.ExitCode -ne 0) {
-            Write-Error "The build unexpectedly failed for project $projectPath."
+            Write-Error "The build for project $projectPath was expected to succeed, but it failed."
         }
     }
 

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -50,8 +50,8 @@ Process {
         BuildProject -openApiMsBuildSource $outputDir -projectPath $codeFirstSysTestDir -isFailureExpected $false
         BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $true
-        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
-        BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiIgnoreErrors=true"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=true"
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=true"
     }
     finally {
         Pop-Location

--- a/src/Workleap.OpenApi.MSBuild.sln
+++ b/src/Workleap.OpenApi.MSBuild.sln
@@ -23,6 +23,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.CodeFirst", "tests\WebApi.MsBuild.SystemTest.CodeFirst\WebApi.MsBuild.SystemTest.CodeFirst.csproj", "{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.OasDiffError", "tests\WebApi.MsBuild.SystemTest.OasDiffError\WebApi.MsBuild.SystemTest.OasDiffError.csproj", "{3909D38E-7584-4206-9CDC-3E56203BE6DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.SpectralError", "tests\WebApi.MsBuild.SystemTest.SpectralError\WebApi.MsBuild.SystemTest.SpectralError.csproj", "{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -52,10 +56,20 @@ Global
 		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A4C90BE2-889F-46BB-8B4D-2219B1084695} = {07F66FC2-73B9-44C7-843C-36C13905AE9B}
 		{B8A81C76-574B-40FD-B34B-FA893D6C1423} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
 		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+		{3909D38E-7584-4206-9CDC-3E56203BE6DB} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
 	EndGlobalSection
 EndGlobal

--- a/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
+++ b/src/Workleap.OpenApi.MSBuild/LoggerWrapper.cs
@@ -5,13 +5,30 @@ namespace Workleap.OpenApi.MSBuild;
 
 internal sealed class LoggerWrapper : ILoggerWrapper
 {
-    private readonly TaskLoggingHelper _taskLoggingHelper;
+    private readonly TaskLoggingHelper _helper;
+    private readonly bool _treatWarningAsError;
 
-    public LoggerWrapper(TaskLoggingHelper helper) => this._taskLoggingHelper = helper;
+    public LoggerWrapper(TaskLoggingHelper helper, bool treatWarningAsError)
+    {
+        this._helper = helper;
+        this._treatWarningAsError = treatWarningAsError;
+    }
+    
+    public void LogMessage(string message, MessageImportance importance = MessageImportance.Low, params object[] messageArgs)
+        => this._helper.LogMessage(importance, message, messageArgs);
 
     public void LogWarning(string message, params object[] messageArgs)
-        => this._taskLoggingHelper.LogWarning(message, messageArgs);
+    {
+        if (this._treatWarningAsError)
+        {
+            this._helper.LogError(message, messageArgs);
+        }
+        else
+        {
+            this._helper.LogWarning(message, messageArgs);
+        }
+    }
 
-    public void LogMessage(string message, MessageImportance importance = MessageImportance.Low, params object[] messageArgs)
-        => this._taskLoggingHelper.LogMessage(importance, message, messageArgs);
+    public void LogError(string message, params object[] messageArgs)
+        => this._helper.LogError(message, messageArgs);
 }

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -63,10 +63,10 @@ internal sealed class OasdiffManager : IOasdiffManager
             if (string.IsNullOrEmpty(result.StandardError))
             {
                 var isChangesDetected = result.ExitCode != 0;
-                this._loggerWrapper.LogMessage("Exit code {0}", MessageImportance.Normal, result.ExitCode);
+                this._loggerWrapper.LogMessage("Oasdiff returned: {0}", MessageImportance.Normal, result.ExitCode);
                 if (isChangesDetected)
                 {
-                    this._loggerWrapper.LogWarning($"Server doesn't match the OpenAPI file: {fileName}. Check the following logs for more details.");
+                    this._loggerWrapper.LogWarning($"Your web API does not implement the following OpenAPI specification: {fileName}. Check the following logs for more details.");
                 }
                 
                 this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -66,7 +66,7 @@ internal sealed class OasdiffManager : IOasdiffManager
                 this._loggerWrapper.LogMessage("Oasdiff returned: {0}", MessageImportance.Normal, result.ExitCode);
                 if (isChangesDetected)
                 {
-                    this._loggerWrapper.LogWarning($"Your web API does not implement the following OpenAPI specification: {fileName}. Check the following logs for more details.");
+                    this._loggerWrapper.LogWarning($"Your web API does not respect the following OpenAPI specification: {fileName}. Please review the logs below for details.");
                 }
                 
                 this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -5,7 +5,7 @@ namespace Workleap.OpenApi.MSBuild;
 
 internal sealed class OasdiffManager : IOasdiffManager
 {
-    private const string OasdiffVersion = "1.9.6";
+    private const string OasdiffVersion = "1.10.11";
     private const string OasdiffDownloadUrlFormat = "https://github.com/Tufin/oasdiff/releases/download/v{0}/{1}";
 
     private readonly ILoggerWrapper _loggerWrapper;
@@ -59,9 +59,19 @@ internal sealed class OasdiffManager : IOasdiffManager
             this._loggerWrapper.LogMessage("- Specification file path: {0}", MessageImportance.High, baseSpecFile);
             this._loggerWrapper.LogMessage("- Specification generated from code path: {0} \n", MessageImportance.High, generatedSpecFilePath);
             
-            var result = await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, generatedSpecFilePath, "--exclude-elements", "description,examples,title,summary", "-f", "text", "-o" }, cancellationToken);
-            this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
-            if (!string.IsNullOrEmpty(result.StandardError))
+            var result = await this._processWrapper.RunProcessAsync(oasdiffExecutePath, new[] { "diff", baseSpecFile, generatedSpecFilePath, "--exclude-elements", "description,examples,title,summary", "-o" }, cancellationToken);
+            if (string.IsNullOrEmpty(result.StandardError))
+            {
+                var isChangesDetected = result.ExitCode != 0;
+                this._loggerWrapper.LogMessage("Exit code {0}", MessageImportance.Normal, result.ExitCode);
+                if (isChangesDetected)
+                {
+                    this._loggerWrapper.LogWarning($"Server doesn't match the OpenAPI file: {fileName}. Check the following logs for more details.");
+                }
+                
+                this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
+            }
+            else
             {
                 this._loggerWrapper.LogWarning(result.StandardError);
             }

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -116,7 +116,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
                     break;
 
                 default:
-                    loggerWrapper.LogError("Invalid value of '{0}' for {1}. Allowed values are '{2}' or '{3}'", this.OpenApiDevelopmentMode, nameof(OpenApiDevelopmentMode), ContractFirst, CodeFirst);
+                    loggerWrapper.LogError("Invalid value of '{0}' for {1}. Allowed values are '{2}' or '{3}'", this.OpenApiDevelopmentMode, nameof(this.OpenApiDevelopmentMode), ContractFirst, CodeFirst);
                     return false;
             }
         }

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -44,11 +44,11 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
     public string[] OpenApiSpecificationFiles { get; set; } = Array.Empty<string>();
 
     /// <summary>If should log error instead of warning</summary>
-    public bool TreatWarningsAsErrors { get; set; }
+    public bool OpenApiTreatWarningsAsErrors { get; set; }
 
     protected override async Task<bool> ExecuteAsync(CancellationToken cancellationToken)
     {
-        var loggerWrapper = new LoggerWrapper(this.Log, this.TreatWarningsAsErrors);
+        var loggerWrapper = new LoggerWrapper(this.Log, this.OpenApiTreatWarningsAsErrors);
 
         loggerWrapper.LogMessage("\n******** Starting {0} ********\n", MessageImportance.Normal, nameof(ValidateOpenApiTask));
 
@@ -67,7 +67,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
 
         loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Normal, nameof(this.OpenApiDevelopmentMode), this.OpenApiDevelopmentMode);
         loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Normal, nameof(this.OpenApiCompareCodeAgainstSpecFile), this.OpenApiCompareCodeAgainstSpecFile);
-        loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Low, nameof(this.TreatWarningsAsErrors), this.TreatWarningsAsErrors);
+        loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Low, nameof(this.OpenApiTreatWarningsAsErrors), this.OpenApiTreatWarningsAsErrors);
         loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Low, nameof(this.OpenApiWebApiAssemblyPath), this.OpenApiWebApiAssemblyPath);
         loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Low, nameof(this.OpenApiToolsDirectoryPath), this.OpenApiToolsDirectoryPath);
         loggerWrapper.LogMessage("{0} = '{1}'", MessageImportance.Low, nameof(this.OpenApiSpectralRulesetUrl), this.OpenApiSpectralRulesetUrl);

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -43,7 +43,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
     [Required]
     public string[] OpenApiSpecificationFiles { get; set; } = Array.Empty<string>();
 
-    /// <summary>If should log error instead of warning</summary>
+    /// <summary>If warnings should be logged as errors instead.</summary>
     public bool OpenApiTreatWarningsAsErrors { get; set; }
 
     protected override async Task<bool> ExecuteAsync(CancellationToken cancellationToken)

--- a/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateOpenApiTask.cs
@@ -89,7 +89,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
             switch (this.OpenApiDevelopmentMode)
             {
                 case CodeFirst:
-                    loggerWrapper.LogMessage("\nStarting code first...", MessageImportance.Normal);
+                    loggerWrapper.LogMessage("\nStarting code first process...", MessageImportance.Normal);
                     await codeFirstProcess.Execute(
                         this.OpenApiSpecificationFiles,
                         this.OpenApiSwaggerDocumentNames,
@@ -99,7 +99,7 @@ public sealed class ValidateOpenApiTask : CancelableAsyncTask
                     break;
 
                 case ContractFirst:
-                    loggerWrapper.LogMessage("\nStarting contract first...", MessageImportance.Normal);
+                    loggerWrapper.LogMessage("\nStarting contract first process...", MessageImportance.Normal);
                     var isSuccess = await contractFirstProcess.Execute(
                         this.OpenApiSpecificationFiles,
                         this.OpenApiToolsDirectoryPath,

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -38,11 +38,8 @@
       <!-- The names of the Swagger documents to generate OpenAPI specifications for -->
       <!-- "v1" is the default Swagger document name. Users can specify multiple values separated by semicolons -->
       <OpenApiSwaggerDocumentNames Condition="'$(OpenApiSwaggerDocumentNames)' == ''">v1</OpenApiSwaggerDocumentNames>
-
-      <!-- Set development mode: ContractFirst or CodeFirst -->
-      <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">ContractFirst</OpenApiDevelopmentMode>
       
-      <!-- Set development mode: ContractFirst or CodeFirst -->
+      <!-- Use TreatWarningsAsErrors property unless it is opt-out with OpenApiIgnoreErrors -->
       <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreErrors)' == 'true'">false</OpenApiTreatWarningsAsErrors>
       <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreErrors)' != 'true'">$(TreatWarningsAsErrors)</OpenApiTreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -38,6 +38,13 @@
       <!-- The names of the Swagger documents to generate OpenAPI specifications for -->
       <!-- "v1" is the default Swagger document name. Users can specify multiple values separated by semicolons -->
       <OpenApiSwaggerDocumentNames Condition="'$(OpenApiSwaggerDocumentNames)' == ''">v1</OpenApiSwaggerDocumentNames>
+
+      <!-- Set development mode: ContractFirst or CodeFirst -->
+      <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">ContractFirst</OpenApiDevelopmentMode>
+      
+      <!-- Set development mode: ContractFirst or CodeFirst -->
+      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreError)' == 'true'">false</OpenApiTreatWarningsAsErrors>
+      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreError)' != 'true'">$(TreatWarningsAsErrors)</OpenApiTreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
@@ -64,7 +71,7 @@
       OpenApiSpectralRulesetUrl="$(OpenApiSpectralRulesetUrl)"
       OpenApiSwaggerDocumentNames="$(OpenApiSwaggerDocumentNames)"
       OpenApiSpecificationFiles="$(OpenApiSpecificationFiles)"
-      TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
+      OpenApiTreatWarningsAsErrors="$(OpenApiTreatWarningsAsErrors)"
     />
   </Target>
 </Project>

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -43,8 +43,8 @@
       <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">ContractFirst</OpenApiDevelopmentMode>
       
       <!-- Set development mode: ContractFirst or CodeFirst -->
-      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreError)' == 'true'">false</OpenApiTreatWarningsAsErrors>
-      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreError)' != 'true'">$(TreatWarningsAsErrors)</OpenApiTreatWarningsAsErrors>
+      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreErrors)' == 'true'">false</OpenApiTreatWarningsAsErrors>
+      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreErrors)' != 'true'">$(TreatWarningsAsErrors)</OpenApiTreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -64,6 +64,7 @@
       OpenApiSpectralRulesetUrl="$(OpenApiSpectralRulesetUrl)"
       OpenApiSwaggerDocumentNames="$(OpenApiSwaggerDocumentNames)"
       OpenApiSpecificationFiles="$(OpenApiSpecificationFiles)"
+      TreatWarningsAsErrors="$(TreatWarningsAsErrors)"
     />
   </Target>
 </Project>

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -39,9 +39,9 @@
       <!-- "v1" is the default Swagger document name. Users can specify multiple values separated by semicolons -->
       <OpenApiSwaggerDocumentNames Condition="'$(OpenApiSwaggerDocumentNames)' == ''">v1</OpenApiSwaggerDocumentNames>
       
-      <!-- Use TreatWarningsAsErrors property unless it is opt-out with OpenApiIgnoreErrors -->
-      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreErrors)' == 'true'">false</OpenApiTreatWarningsAsErrors>
-      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiIgnoreErrors)' != 'true'">$(TreatWarningsAsErrors)</OpenApiTreatWarningsAsErrors>
+      <!-- Use TreatWarningsAsErrors property unless it is opt-out with OpenApiTreatWarningsAsErrors, fallback to false if both are unset -->
+      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiTreatWarningsAsErrors)' == ''">$(TreatWarningsAsErrors)</OpenApiTreatWarningsAsErrors>
+      <OpenApiTreatWarningsAsErrors Condition="'$(OpenApiTreatWarningsAsErrors)' == ''">false</OpenApiTreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.CodeFirst/WebApi.MsBuild.SystemTest.CodeFirst.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.CodeFirst/WebApi.MsBuild.SystemTest.CodeFirst.csproj
@@ -11,6 +11,7 @@
     <PropertyGroup>
       <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.ContractFirst/WebApi.MsBuild.SystemTest.ContractFirst.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.ContractFirst/WebApi.MsBuild.SystemTest.ContractFirst.csproj
@@ -14,6 +14,7 @@
       <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Controllers/WeatherForecastController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Controllers/WeatherForecastController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        this._logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)],
+            })
+            .ToArray();
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Controllers/WeatherManagementController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Controllers/WeatherManagementController.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1-management")]
+public class WeatherManagementController : ControllerBase
+{
+    private static readonly string[] Sources =
+    {
+        "Accuweather", "AerisWeather", "Foreca", "Open Weathermap", "National Oceanic and Atmospheric Administration",
+    };
+    
+    private readonly ILogger<WeatherManagementController> _logger;
+    
+    public WeatherManagementController(ILogger<WeatherManagementController> logger)
+    {
+        this._logger = logger;
+    }
+    
+    [HttpGet(Name = "GetWeatherSources")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<string> Get()
+    {
+        return Sources;
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Program.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "V1 API General", Version = "v1" });
+    c.SwaggerDoc("v1-management", new OpenApiInfo { Title = "V1 API management", Version = "v1-management" });
+});
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("v1/swagger.json", "v1");
+    options.SwaggerEndpoint("v1-management/swagger.json", "v1-management");
+});
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Properties/launchSettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65488",
+      "sslPort": 44333
+    }
+  },
+  "profiles": {
+    "WebApi.SystemTest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7045;http://localhost:5245",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/WeatherForecast.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace WebApi.MsBuild.SystemTest;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; init; }
+
+    public int TemperatureF => 32 + (int)(this.TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/WebApi.MsBuild.SystemTest.OasDiffError.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/WebApi.MsBuild.SystemTest.OasDiffError.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+        <RootNamespace>WebApi.MsBuild.SystemTest</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+      <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
+      <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    </ItemGroup>
+
+</Project>

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/appsettings.Development.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/appsettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/openapi-v1-management.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/openapi-v1-management.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.1
+info:
+  title: V1 API management
+  version: v1-management
+paths:
+  /WeatherManagement:
+    get:
+      tags:
+        - WeatherManagement
+      operationId: GetWeatherSources
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: {}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/openapi-v1.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/openapi-v1.yaml
@@ -1,0 +1,64 @@
+openapi: 2.0.1
+info:
+  title: V1 API General
+  version: v1
+paths:
+  /WeatherForecast2:
+    get:
+      tags:
+        - WeatherForecast
+      operationId: GetWeatherForecast
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherForecast'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: {}
+    WeatherForecast:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date-time
+        temperatureC:
+          type: integer
+          format: int32
+        temperatureF:
+          type: integer
+          format: int32
+          readOnly: true
+        summary:
+          type: string
+          nullable: true
+      additionalProperties: false

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Controllers/WeatherForecastController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Controllers/WeatherForecastController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        this._logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)],
+            })
+            .ToArray();
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Controllers/WeatherManagementController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Controllers/WeatherManagementController.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1-management")]
+public class WeatherManagementController : ControllerBase
+{
+    private static readonly string[] Sources =
+    {
+        "Accuweather", "AerisWeather", "Foreca", "Open Weathermap", "National Oceanic and Atmospheric Administration",
+    };
+    
+    private readonly ILogger<WeatherManagementController> _logger;
+    
+    public WeatherManagementController(ILogger<WeatherManagementController> logger)
+    {
+        this._logger = logger;
+    }
+    
+    [HttpGet(Name = "GetWeatherSources")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<string> Get()
+    {
+        return Sources;
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Program.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "V1 API General", Version = "v1" });
+    c.SwaggerDoc("v1-management", new OpenApiInfo { Title = "V1 API management", Version = "v1-management" });
+});
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("v1/swagger.json", "v1");
+    options.SwaggerEndpoint("v1-management/swagger.json", "v1-management");
+});
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Properties/launchSettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65488",
+      "sslPort": 44333
+    }
+  },
+  "profiles": {
+    "WebApi.SystemTest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7045;http://localhost:5245",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/WeatherForecast.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace WebApi.MsBuild.SystemTest;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; init; }
+
+    public int TemperatureF => 32 + (int)(this.TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/WebApi.MsBuild.SystemTest.SpectralError.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/WebApi.MsBuild.SystemTest.SpectralError.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <IsPackable>false</IsPackable>
+        <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
+        <RootNamespace>WebApi.MsBuild.SystemTest</RootNamespace>
+    </PropertyGroup>
+
+    <PropertyGroup>
+      <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+      <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
+      <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
+      <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    </ItemGroup>
+  
+</Project>

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/appsettings.Development.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/appsettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/openapi-v1-management.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/openapi-v1-management.yaml
@@ -1,0 +1,47 @@
+openapi: 3.0.1
+info:
+  title: V1 API management
+  version: v1-management
+paths:
+  /WeatherManagement:
+    get:
+      tags:
+        - WeatherManagement
+      operationId: GetWeatherSources
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: {}

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/openapi-v1.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/openapi-v1.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.1
+info:
+  title: V1 API General
+  version: v1
+paths:
+  /WeatherForecast2:
+    get:
+      tags:
+        - WeatherForecast
+      operationId: GetWeatherForecast
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherForecast'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: {}
+    WeatherForecast:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date-time
+        temperatureC:
+          type: integer
+          format: int32
+        temperatureF:
+          type: integer
+          format: int32
+          readOnly: true
+        summary:
+          type: string
+          nullable: true
+      additionalProperties: false


### PR DESCRIPTION
## Description of changes
Support the <TreatWarningsAsErrors> property. If OasDiff or Spectral step validation fail it will log errror instead of warning.

Add option to opt-out with OpenApiIgnoreErrors


## Breaking changes
Yes, if this library was logging warning in a current project and they use the TreatWarningsAsErrors flag it will fail their build.

## Additional checks
- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
