### PR TITLE
Update to match LGTM on Contract-First with annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Validates at build time that the OpenAPI specification files extracted from the ASP.NET Core Web API being built conform to Workleap API guidelines.
 
-Depending if the user chose the Contract-First or Code-First development mode this MSBuild task will:
+Depending if the user chose the ValidateContract or GenerateContract development mode this MSBuild task will:
 
 - Install tools: [OasDiff](https://github.com/Tufin/oasdiff), [Spectral](https://github.com/stoplightio/spectral), [SwashbuckleCLI](https://github.com/domaindrivendev/Swashbuckle.AspNetCore?tab=readme-ov-file#swashbuckleaspnetcorecli)
 - Generate the OpenAPI specification file from the associated Web API

--- a/Run-SystemTest.ps1
+++ b/Run-SystemTest.ps1
@@ -36,7 +36,9 @@ Process {
     $outputDir = Join-Path $PSScriptRoot ".output"
     
     $contractFirstSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.ContractFirst"
+    $validateContractSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.ValidateContract"
     $codeFirstSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.CodeFirst"
+    $generateContractSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.GenerateContract"
     $oasDiffErrorSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.OasDiffError"
     $spectralErrorSysTestDir = Join-Path $PSScriptRoot "src/tests/WebApi.MsBuild.SystemTest.SpectralError"
 
@@ -47,7 +49,9 @@ Process {
         Exec { & dotnet pack -c Release -o "$outputDir" }
 
         BuildProject -openApiMsBuildSource $outputDir -projectPath $contractFirstSysTestDir -isFailureExpected $false
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $validateContractSysTestDir -isFailureExpected $false
         BuildProject -openApiMsBuildSource $outputDir -projectPath $codeFirstSysTestDir -isFailureExpected $false
+        BuildProject -openApiMsBuildSource $outputDir -projectPath $generateContractSysTestDir -isFailureExpected $false
         BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $true
         BuildProject -openApiMsBuildSource $outputDir -projectPath $spectralErrorSysTestDir -isFailureExpected $true
         BuildProject -openApiMsBuildSource $outputDir -projectPath $oasDiffErrorSysTestDir -isFailureExpected $false -extraArgs "/p:OpenApiTreatWarningsAsErrors=false"

--- a/src/WebApiDebugger/Properties/launchSettings.json
+++ b/src/WebApiDebugger/Properties/launchSettings.json
@@ -1,28 +1,28 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
-    "ContractFirstWithoutCompare": {
+    "ValidateContractWithoutCompare": {
       "commandName": "Executable",
       "executablePath": "dotnet",
-      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=ContractFirst /p:OpenApiCompareCodeAgainstSpecFile=false",
+      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=ValidateContract /p:OpenApiCompareCodeAgainstSpecFile=false",
       "workingDirectory": "$(ProjectDir)"
     },
-    "ContractFirstWithCompare": {
+    "ValidateContractWithCompare": {
       "commandName": "Executable",
       "executablePath": "dotnet",
-      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=ContractFirst /p:OpenApiCompareCodeAgainstSpecFile=true",
+      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=ValidateContract /p:OpenApiCompareCodeAgainstSpecFile=true",
       "workingDirectory": "$(ProjectDir)"
     },
-    "CodeFirst": {
+    "GenerateContract": {
       "commandName": "Executable",
       "executablePath": "dotnet",
-      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=CodeFirst",
+      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=GenerateContract",
       "workingDirectory": "$(ProjectDir)"
     },
-    "CodeFirstOnCI": {
+    "GenerateContractOnCI": {
       "commandName": "Executable",
       "executablePath": "dotnet",
-      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=CodeFirst /p:OpenApiCompareCodeAgainstSpecFile=true",
+      "commandLineArgs": "msbuild /t:ValidateOpenApi /p:OpenApiDevelopmentMode=GenerateContract /p:OpenApiCompareCodeAgainstSpecFile=true",
       "workingDirectory": "$(ProjectDir)"
     },
     "WebApiDebugger": {

--- a/src/WebApiDebugger/WebApiDebugger.csproj
+++ b/src/WebApiDebugger/WebApiDebugger.csproj
@@ -14,7 +14,7 @@
 
   <PropertyGroup>
     <OpenApiDebuggingEnabled>true</OpenApiDebuggingEnabled>
-    <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+    <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Workleap.OpenApi.MSBuild.sln
+++ b/src/Workleap.OpenApi.MSBuild.sln
@@ -3,37 +3,38 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Workleap.OpenApi.MSBuild", "Workleap.OpenApi.MSBuild\Workleap.OpenApi.MSBuild.csproj", "{4479DD41-F9CE-4DFD-8F7C-4ACC25BE203C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Workleap.OpenApi.MSBuild", "Workleap.OpenApi.MSBuild\Workleap.OpenApi.MSBuild.csproj", "{4479DD41-F9CE-4DFD-8F7C-4ACC25BE203C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{3B3625CC-919B-4216-9B50-BCFE297AA184}"
 	ProjectSection(SolutionItems) = preProject
-		Directory.Build.props = Directory.Build.props
 		.editorconfig = .editorconfig
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Workleap.OpenApi.MSBuild.Tests", "Workleap.OpenApi.MSBuild.Tests\Workleap.OpenApi.MSBuild.Tests.csproj", "{2A5429CC-E179-47E7-85BB-C1E33E2AFD8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Workleap.OpenApi.MSBuild.Tests", "Workleap.OpenApi.MSBuild.Tests\Workleap.OpenApi.MSBuild.Tests.csproj", "{2A5429CC-E179-47E7-85BB-C1E33E2AFD8A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "debug", "debug", "{07F66FC2-73B9-44C7-843C-36C13905AE9B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApiDebugger", "WebApiDebugger\WebApiDebugger.csproj", "{A4C90BE2-889F-46BB-8B4D-2219B1084695}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApiDebugger", "WebApiDebugger\WebApiDebugger.csproj", "{A4C90BE2-889F-46BB-8B4D-2219B1084695}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{4DDE83BF-D190-4CC9-AD36-E9250DABB27D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.ContractFirst", "tests\WebApi.MsBuild.SystemTest.ContractFirst\WebApi.MsBuild.SystemTest.ContractFirst.csproj", "{B8A81C76-574B-40FD-B34B-FA893D6C1423}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.MsBuild.SystemTest.OasDiffError", "tests\WebApi.MsBuild.SystemTest.OasDiffError\WebApi.MsBuild.SystemTest.OasDiffError.csproj", "{3909D38E-7584-4206-9CDC-3E56203BE6DB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.CodeFirst", "tests\WebApi.MsBuild.SystemTest.CodeFirst\WebApi.MsBuild.SystemTest.CodeFirst.csproj", "{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.MsBuild.SystemTest.SpectralError", "tests\WebApi.MsBuild.SystemTest.SpectralError\WebApi.MsBuild.SystemTest.SpectralError.csproj", "{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.OasDiffError", "tests\WebApi.MsBuild.SystemTest.OasDiffError\WebApi.MsBuild.SystemTest.OasDiffError.csproj", "{3909D38E-7584-4206-9CDC-3E56203BE6DB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.MsBuild.SystemTest.ValidateContract", "tests\WebApi.MsBuild.SystemTest.ValidateContract\WebApi.MsBuild.SystemTest.ValidateContract.csproj", "{CCDEB7C9-EE1C-416D-871B-00FD8269B5FA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApi.MsBuild.SystemTest.SpectralError", "tests\WebApi.MsBuild.SystemTest.SpectralError\WebApi.MsBuild.SystemTest.SpectralError.csproj", "{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.MsBuild.SystemTest.GenerateContract", "tests\WebApi.MsBuild.SystemTest.GenerateContract\WebApi.MsBuild.SystemTest.GenerateContract.csproj", "{502CEF5F-350E-4498-BA3C-3C09C9620737}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.MsBuild.SystemTest.CodeFirst", "tests\WebApi.MsBuild.SystemTest.CodeFirst\WebApi.MsBuild.SystemTest.CodeFirst.csproj", "{49EEB542-9B68-4389-810D-0C1222E5FD17}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApi.MsBuild.SystemTest.ContractFirst", "tests\WebApi.MsBuild.SystemTest.ContractFirst\WebApi.MsBuild.SystemTest.ContractFirst.csproj", "{DE929AE5-5A69-4E82-8246-7AD5BF97983B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{4479DD41-F9CE-4DFD-8F7C-4ACC25BE203C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -48,14 +49,6 @@ Global
 		{A4C90BE2-889F-46BB-8B4D-2219B1084695}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A4C90BE2-889F-46BB-8B4D-2219B1084695}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A4C90BE2-889F-46BB-8B4D-2219B1084695}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B8A81C76-574B-40FD-B34B-FA893D6C1423}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B8A81C76-574B-40FD-B34B-FA893D6C1423}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B8A81C76-574B-40FD-B34B-FA893D6C1423}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B8A81C76-574B-40FD-B34B-FA893D6C1423}.Release|Any CPU.Build.0 = Release|Any CPU
-		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3909D38E-7584-4206-9CDC-3E56203BE6DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -64,12 +57,36 @@ Global
 		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CCDEB7C9-EE1C-416D-871B-00FD8269B5FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CCDEB7C9-EE1C-416D-871B-00FD8269B5FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CCDEB7C9-EE1C-416D-871B-00FD8269B5FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CCDEB7C9-EE1C-416D-871B-00FD8269B5FA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{502CEF5F-350E-4498-BA3C-3C09C9620737}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{502CEF5F-350E-4498-BA3C-3C09C9620737}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{502CEF5F-350E-4498-BA3C-3C09C9620737}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{502CEF5F-350E-4498-BA3C-3C09C9620737}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49EEB542-9B68-4389-810D-0C1222E5FD17}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49EEB542-9B68-4389-810D-0C1222E5FD17}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49EEB542-9B68-4389-810D-0C1222E5FD17}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49EEB542-9B68-4389-810D-0C1222E5FD17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE929AE5-5A69-4E82-8246-7AD5BF97983B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE929AE5-5A69-4E82-8246-7AD5BF97983B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE929AE5-5A69-4E82-8246-7AD5BF97983B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE929AE5-5A69-4E82-8246-7AD5BF97983B}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{A4C90BE2-889F-46BB-8B4D-2219B1084695} = {07F66FC2-73B9-44C7-843C-36C13905AE9B}
-		{B8A81C76-574B-40FD-B34B-FA893D6C1423} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
-		{575E14D8-52E8-4B5B-A93C-D3E86E30BD3C} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
 		{3909D38E-7584-4206-9CDC-3E56203BE6DB} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
 		{C42C2836-4997-49D3-9BC6-E6A0E1B8C472} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+		{CCDEB7C9-EE1C-416D-871B-00FD8269B5FA} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+		{502CEF5F-350E-4498-BA3C-3C09C9620737} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+		{49EEB542-9B68-4389-810D-0C1222E5FD17} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+		{DE929AE5-5A69-4E82-8246-7AD5BF97983B} = {4DDE83BF-D190-4CC9-AD36-E9250DABB27D}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BCD029BE-FB3E-45A2-8DD4-FDE33D87544D}
 	EndGlobalSection
 EndGlobal

--- a/src/Workleap.OpenApi.MSBuild/GenerateContractProcess.cs
+++ b/src/Workleap.OpenApi.MSBuild/GenerateContractProcess.cs
@@ -1,12 +1,12 @@
-﻿namespace Workleap.OpenApi.MSBuild;
+namespace Workleap.OpenApi.MSBuild;
 
 /// <summary>
-/// For a Code First approach it will:
+/// For a GenerateContract approach it will:
 ///     1. Generate the OpenAPI specification files from the code
-///     2. Depending of <see cref="CodeFirstMode"/> it will either will compare the generated OpenAPI specification files against the provided specifications or it will update the source-controlled specification files 
+///     2. Depending of <see cref="GenerateContractMode"/> it will either will compare the generated OpenAPI specification files against the provided specifications or it will update the source-controlled specification files 
 ///     2. Validate the OpenAPI specification files base on spectral rules 
 /// </summary>
-internal class CodeFirstProcess
+internal class GenerateContractProcess
 {
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly SpectralManager _spectralManager;
@@ -14,7 +14,7 @@ internal class CodeFirstProcess
     private readonly SpecGeneratorManager _specGeneratorManager;
     private readonly OasdiffManager _oasdiffManager;
 
-    internal CodeFirstProcess(ILoggerWrapper loggerWrapper, SpectralManager spectralManager, SwaggerManager swaggerManager, SpecGeneratorManager specGeneratorManager, OasdiffManager oasdiffManager)
+    internal GenerateContractProcess(ILoggerWrapper loggerWrapper, SpectralManager spectralManager, SwaggerManager swaggerManager, SpecGeneratorManager specGeneratorManager, OasdiffManager oasdiffManager)
     {
         this._loggerWrapper = loggerWrapper;
         this._spectralManager = spectralManager;
@@ -23,7 +23,7 @@ internal class CodeFirstProcess
         this._oasdiffManager = oasdiffManager;
     }
     
-    internal enum CodeFirstMode
+    internal enum GenerateContractMode
     {
         SpecGeneration,
         SpecComparison,
@@ -33,7 +33,7 @@ internal class CodeFirstProcess
         string[] openApiSpecificationFilesPath,
         string[] openApiSwaggerDocumentNames,
         string openApiSpectralRulesetUrl,
-        CodeFirstMode mode,
+        GenerateContractMode mode,
         CancellationToken cancellationToken)
     {
         this._loggerWrapper.LogMessage("Installing dependencies...");
@@ -42,7 +42,7 @@ internal class CodeFirstProcess
         this._loggerWrapper.LogMessage("Running Swagger...");
         var generateOpenApiDocsPath = (await this._swaggerManager.RunSwaggerAsync(openApiSwaggerDocumentNames, cancellationToken)).ToList();
 
-        if (mode == CodeFirstMode.SpecGeneration)
+        if (mode == GenerateContractMode.SpecGeneration)
         {
             this._loggerWrapper.LogMessage("Generating specification files...");
             await this._specGeneratorManager.UpdateSpecificationFilesAsync(openApiSpecificationFilesPath, generateOpenApiDocsPath, cancellationToken);
@@ -58,14 +58,14 @@ internal class CodeFirstProcess
     }
 
     private async Task InstallDependencies(
-        CodeFirstMode mode,
+        GenerateContractMode mode,
         CancellationToken cancellationToken)
     {
         var installationTasks = new List<Task>();    
         installationTasks.Add(this._spectralManager.InstallSpectralAsync(cancellationToken));        
         installationTasks.Add(this._swaggerManager.InstallSwaggerCliAsync(cancellationToken));
         
-        if (mode == CodeFirstMode.SpecComparison)
+        if (mode == GenerateContractMode.SpecComparison)
         {
             installationTasks.Add(this._oasdiffManager.InstallOasdiffAsync(cancellationToken));
         }

--- a/src/Workleap.OpenApi.MSBuild/ValidateContractProcess.cs
+++ b/src/Workleap.OpenApi.MSBuild/ValidateContractProcess.cs
@@ -1,18 +1,18 @@
-﻿namespace Workleap.OpenApi.MSBuild;
+namespace Workleap.OpenApi.MSBuild;
 
 /// <summary>
-/// For a Contract First approach it will:
+/// For a ValidateContract approach it will:
 ///     1. Validate the OpenAPI specification files base on spectral rules
 ///     2. If <see cref="CompareCodeAgainstSpecFile"/> is enabled, will generate the OpenAPI specification files from the code and validate if it match the provided specifications.
 /// </summary>
-internal class ContractFirstProcess
+internal class ValidateContractProcess
 {
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly SpectralManager _spectralManager;
     private readonly SwaggerManager _swaggerManager;
     private readonly OasdiffManager _oasdiffManager;
     
-    internal ContractFirstProcess(ILoggerWrapper loggerWrapper, SpectralManager spectralManager, SwaggerManager swaggerManager, OasdiffManager oasdiffManager)
+    internal ValidateContractProcess(ILoggerWrapper loggerWrapper, SpectralManager spectralManager, SwaggerManager swaggerManager, OasdiffManager oasdiffManager)
     {
         this._loggerWrapper = loggerWrapper;
         this._spectralManager = spectralManager;

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -20,7 +20,11 @@
       <!-- Set development mode: ValidateContract or GenerateContract -->
       <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">GenerateContract</OpenApiDevelopmentMode>
 
-      <!-- When ValidateContract, validate if the provided specification files match the code -->
+      <!-- Validate if the provided specification files match the code -->
+      <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == '' and '$(OpenApiDevelopmentMode)' == 'ValidateContract'">true</OpenApiCompareCodeAgainstSpecFile>
+      <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == '' and '$(OpenApiDevelopmentMode)' == 'ContractFirst'">true</OpenApiCompareCodeAgainstSpecFile>
+      <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == '' and '$(OpenApiDevelopmentMode)' == 'GenerateContract' and '$(Configuration)' == 'Release'">true</OpenApiCompareCodeAgainstSpecFile>
+      <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == '' and '$(OpenApiDevelopmentMode)' == 'CodeFirst' and '$(Configuration)' == 'Release'">true</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == ''">false</OpenApiCompareCodeAgainstSpecFile>
       
       <!-- The path of the ASP.NET Core project build output directory -->

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -17,10 +17,10 @@
   <!-- We can only analyze the OpenAPI spec after the project has been built -->
   <Target Name="ValidateOpenApi" DependsOnTargets="ResolveProjectReferences" AfterTargets="Build" Condition="'$(OpenApiEnabled)' == 'true'">
     <PropertyGroup>
-      <!-- Set development mode: ContractFirst or CodeFirst -->
-      <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">ContractFirst</OpenApiDevelopmentMode>
+      <!-- Set development mode: ValidateContract or GenerateContract -->
+      <OpenApiDevelopmentMode Condition="'$(OpenApiDevelopmentMode)' == ''">GenerateContract</OpenApiDevelopmentMode>
 
-      <!-- When ContractFirst, validate if the provided specification files match the code -->
+      <!-- When ValidateContract, validate if the provided specification files match the code -->
       <OpenApiCompareCodeAgainstSpecFile Condition="'$(OpenApiCompareCodeAgainstSpecFile)' == ''">false</OpenApiCompareCodeAgainstSpecFile>
       
       <!-- The path of the ASP.NET Core project build output directory -->

--- a/src/tests/WebApi.MsBuild.SystemTest.CodeFirst/WebApi.MsBuild.SystemTest.CodeFirst.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.CodeFirst/WebApi.MsBuild.SystemTest.CodeFirst.csproj
@@ -10,6 +10,7 @@
 
     <PropertyGroup>
       <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+      <OpenApiCompareCodeAgainstSpecFile>false</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.ContractFirst/WebApi.MsBuild.SystemTest.ContractFirst.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.ContractFirst/WebApi.MsBuild.SystemTest.ContractFirst.csproj
@@ -19,10 +19,6 @@
 
     <ItemGroup>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.4.0">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Controllers/WeatherForecastController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Controllers/WeatherForecastController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        this._logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)],
+            })
+            .ToArray();
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Controllers/WeatherManagementController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Controllers/WeatherManagementController.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1-management")]
+public class WeatherManagementController : ControllerBase
+{
+    private static readonly string[] Sources =
+    {
+        "Accuweather", "AerisWeather", "Foreca", "Open Weathermap", "National Oceanic and Atmospheric Administration",
+    };
+    
+    private readonly ILogger<WeatherManagementController> _logger;
+    
+    public WeatherManagementController(ILogger<WeatherManagementController> logger)
+    {
+        this._logger = logger;
+    }
+    
+    [HttpGet(Name = "GetWeatherSources")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<WeatherSource> Get()
+    {
+        return Sources.Select(x => new WeatherSource { Source = x });
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Program.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "V1 API General", Version = "v1" });
+    c.SwaggerDoc("v1-management", new OpenApiInfo { Title = "V1 API management", Version = "v1-management" });
+});
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("v1/swagger.json", "v1");
+    options.SwaggerEndpoint("v1-management/swagger.json", "v1-management");
+});
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Properties/launchSettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/Properties/launchSettings.json
@@ -1,0 +1,26 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "WebApi.SystemTest.Local": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7045;http://localhost:5245",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "WebApi.SystemTest.CI": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7045;http://localhost:5245",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "WL_DISABLE_SPECGEN": "true"
+      }
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WeatherForecast.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace WebApi.MsBuild.SystemTest;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; init; }
+
+    public int TemperatureF => 32 + (int)(this.TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WeatherSource.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WeatherSource.cs
@@ -1,0 +1,6 @@
+﻿namespace WebApi.MsBuild.SystemTest;
+
+public class WeatherSource
+{
+    public required string Source { get; set; }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WebApi.MsBuild.SystemTest.GenerateContract.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WebApi.MsBuild.SystemTest.GenerateContract.csproj
@@ -10,6 +10,7 @@
 
     <PropertyGroup>
       <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
+      <OpenApiCompareCodeAgainstSpecFile>false</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WebApi.MsBuild.SystemTest.GenerateContract.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/WebApi.MsBuild.SystemTest.GenerateContract.csproj
@@ -1,5 +1,4 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
@@ -10,25 +9,12 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <OpenApiDevelopmentMode>ContractFirst</OpenApiDevelopmentMode>
-      <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
+      <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
-      <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.4.0">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
-
-    <ItemGroup>
-      <None Update="custom.spectral.yaml">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </None>
-    </ItemGroup>
-
 </Project>

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/appsettings.Development.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/appsettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.GenerateContract/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/WebApi.MsBuild.SystemTest.OasDiffError.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.OasDiffError/WebApi.MsBuild.SystemTest.OasDiffError.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+      <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
       <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/tests/WebApi.MsBuild.SystemTest.SpectralError/WebApi.MsBuild.SystemTest.SpectralError.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.SpectralError/WebApi.MsBuild.SystemTest.SpectralError.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <OpenApiDevelopmentMode>CodeFirst</OpenApiDevelopmentMode>
+      <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
       <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Controllers/WeatherForecastController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Controllers/WeatherForecastController.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1")]
+public class WeatherForecastController : ControllerBase
+{
+    private static readonly string[] Summaries = new[]
+    {
+        "Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching",
+    };
+
+    private readonly ILogger<WeatherForecastController> _logger;
+
+    public WeatherForecastController(ILogger<WeatherForecastController> logger)
+    {
+        this._logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherForecast")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<WeatherForecast> Get()
+    {
+        return Enumerable.Range(1, 5).Select(index => new WeatherForecast
+            {
+                Date = DateTime.Now.AddDays(index),
+                TemperatureC = Random.Shared.Next(-20, 55),
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)],
+            })
+            .ToArray();
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Controllers/WeatherManagementController.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Controllers/WeatherManagementController.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApi.MsBuild.SystemTest.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+[Produces("application/json")]
+[ApiExplorerSettings(GroupName = "v1-management")]
+public class WeatherManagementController : ControllerBase
+{
+    private static readonly string[] Sources =
+    {
+        "Accuweather", "AerisWeather", "Foreca", "Open Weathermap", "National Oceanic and Atmospheric Administration",
+    };
+
+    private readonly ILogger<WeatherManagementController> _logger;
+
+    public WeatherManagementController(ILogger<WeatherManagementController> logger)
+    {
+        this._logger = logger;
+    }
+
+    [HttpGet(Name = "GetWeatherSources")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    public IEnumerable<WeatherSource> Get()
+    {
+        return Sources.Select(x => new WeatherSource { Source = x });
+    }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Program.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.OpenApi.Models;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "V1 API General", Version = "v1" });
+    c.SwaggerDoc("v1-management", new OpenApiInfo { Title = "V1 API management", Version = "v1-management" });
+});
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI(options =>
+{
+    options.SwaggerEndpoint("v1/swagger.json", "v1");
+    options.SwaggerEndpoint("v1-management/swagger.json", "v1-management");
+});
+
+app.UseHttpsRedirection();
+
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Properties/launchSettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/Properties/launchSettings.json
@@ -1,0 +1,31 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:65488",
+      "sslPort": 44333
+    }
+  },
+  "profiles": {
+    "WebApi.SystemTest": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7045;http://localhost:5245",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WeatherForecast.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WeatherForecast.cs
@@ -1,0 +1,12 @@
+namespace WebApi.MsBuild.SystemTest;
+
+public class WeatherForecast
+{
+    public DateTime Date { get; set; }
+
+    public int TemperatureC { get; init; }
+
+    public int TemperatureF => 32 + (int)(this.TemperatureC / 0.5556);
+
+    public string? Summary { get; set; }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WeatherSource.cs
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WeatherSource.cs
@@ -1,0 +1,6 @@
+﻿namespace WebApi.MsBuild.SystemTest;
+
+public class WeatherSource
+{
+    public required string Source { get; set; }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WebApi.MsBuild.SystemTest.ValidateContract.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WebApi.MsBuild.SystemTest.ValidateContract.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
+      <OpenApiDevelopmentMode>ValidateContract</OpenApiDevelopmentMode>
       <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WebApi.MsBuild.SystemTest.ValidateContract.csproj
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/WebApi.MsBuild.SystemTest.ValidateContract.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <OpenApiDevelopmentMode>ContractFirst</OpenApiDevelopmentMode>
+      <OpenApiDevelopmentMode>GenerateContract</OpenApiDevelopmentMode>
       <OpenApiCompareCodeAgainstSpecFile>true</OpenApiCompareCodeAgainstSpecFile>
       <OpenApiSwaggerDocumentNames>v1;v1-management</OpenApiSwaggerDocumentNames>
       <OpenApiSpectralRulesetUrl>./custom.spectral.yaml</OpenApiSpectralRulesetUrl>
@@ -19,10 +19,6 @@
 
     <ItemGroup>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-        <PackageReference Include="Workleap.OpenApi.MSBuild" Version="0.4.0">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/appsettings.Development.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/appsettings.json
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/custom.spectral.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/custom.spectral.yaml
@@ -1,0 +1,3 @@
+extends: [https://raw.githubusercontent.com/gsoft-inc/wl-api-guidelines/0.1.0/.spectral.yaml]
+rules:
+  duplicated-entry-in-enum: false

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/openapi-v1-management.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/openapi-v1-management.yaml
@@ -1,0 +1,54 @@
+openapi: 3.0.1
+info:
+  title: V1 API management
+  version: v1-management
+paths:
+  /WeatherManagement:
+    get:
+      tags:
+        - WeatherManagement
+      operationId: GetWeatherSources
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherSource'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: { }
+    WeatherSource:
+      type: object
+      properties:
+        source:
+          type: string
+          nullable: true
+      additionalProperties: false

--- a/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/openapi-v1.yaml
+++ b/src/tests/WebApi.MsBuild.SystemTest.ValidateContract/openapi-v1.yaml
@@ -1,0 +1,64 @@
+openapi: 3.0.1
+info:
+  title: V1 API General
+  version: v1
+paths:
+  /WeatherForecast:
+    get:
+      tags:
+        - WeatherForecast
+      operationId: GetWeatherForecast
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/WeatherForecast'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProblemDetails'
+components:
+  schemas:
+    ProblemDetails:
+      type: object
+      properties:
+        type:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        status:
+          type: integer
+          format: int32
+          nullable: true
+        detail:
+          type: string
+          nullable: true
+        instance:
+          type: string
+          nullable: true
+      additionalProperties: { }
+    WeatherForecast:
+      type: object
+      properties:
+        date:
+          type: string
+          format: date-time
+        temperatureC:
+          type: integer
+          format: int32
+        temperatureF:
+          type: integer
+          format: int32
+          readOnly: true
+        summary:
+          type: string
+          nullable: true
+      additionalProperties: false


### PR DESCRIPTION
Replace Code-First and Contract-First with GenerateContract and ValidateContract with default to GenerateContract

<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Replace Code-First and Contract-First with GenerateContract and ValidateContract
Set Default to GenerateContract

## Breaking changes
**NONE** Kept CodeFirst and ContractFirst for backward compatibility

- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
