### PR TITLE
[IDP-1484] Add logging and retry for swagger OpenAPI spec generation

### DIFF
--- a/src/Workleap.OpenApi.MSBuild/GenerateContractProcess.cs
+++ b/src/Workleap.OpenApi.MSBuild/GenerateContractProcess.cs
@@ -58,7 +58,6 @@ internal class GenerateContractProcess
         await this._spectralManager.RunSpectralAsync(generateOpenApiDocsPath, cancellationToken);
     }
 
-    // should have a retry or timeout here?
     private async Task InstallDependencies(
         GenerateContractMode mode,
         CancellationToken cancellationToken)

--- a/src/Workleap.OpenApi.MSBuild/GenerateContractProcess.cs
+++ b/src/Workleap.OpenApi.MSBuild/GenerateContractProcess.cs
@@ -1,3 +1,5 @@
+using Microsoft.Build.Framework;
+
 namespace Workleap.OpenApi.MSBuild;
 
 /// <summary>
@@ -56,6 +58,7 @@ internal class GenerateContractProcess
         await this._spectralManager.RunSpectralAsync(generateOpenApiDocsPath, cancellationToken);
     }
 
+    // should have a retry or timeout here?
     private async Task InstallDependencies(
         GenerateContractMode mode,
         CancellationToken cancellationToken)
@@ -70,5 +73,6 @@ internal class GenerateContractProcess
         }
 
         await Task.WhenAll(installationTasks);
+        this._loggerWrapper.LogMessage("Finished installing OpenAPI dependencies.", MessageImportance.High);
     }
 }

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -47,14 +47,14 @@ internal sealed class SwaggerManager : ISwaggerManager
         }
 
         var retryCount = 0;
-        while (retryCount < 2)
+        while (retryCount < 3)
         {
             var result = await this._processWrapper.RunProcessAsync(
                 "dotnet",
                 ["tool", "update", "Swashbuckle.AspNetCore.Cli", "--ignore-failed-sources", "--tool-path", this._swaggerDirectory, "--configfile", Path.Combine(this._openApiToolsDirectoryPath, "nuget.config"), "--version", SwaggerVersion],
                 cancellationToken);
 
-            if (result.ExitCode != 0 && retryCount != 1)
+            if (result.ExitCode != 0 && retryCount != 2)
             {
                 this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
                 this._loggerWrapper.LogWarning(result.StandardError);
@@ -64,7 +64,7 @@ internal sealed class SwaggerManager : ISwaggerManager
                 continue;
             }
 
-            if (retryCount == 1 && result.ExitCode != 0)
+            if (retryCount == 2 && result.ExitCode != 0)
             {
                 throw new OpenApiTaskFailedException("Swashbuckle CLI could not be installed.");
             }

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -77,23 +77,23 @@ internal sealed class SwaggerManager : ISwaggerManager
     {
         var envVars = new Dictionary<string, string?>() { { "DOTNET_ROLL_FORWARD", "LatestMajor" } };
         var retryCount = 0;
-        while (retryCount < 2)
+        while (retryCount < 3)
         {
             var result = await this._processWrapper.RunProcessAsync(swaggerExePath, ["tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName], cancellationToken: cancellationToken, envVars: envVars);
 
-            if (result.ExitCode != 0 && retryCount != 1)
+            if (result.ExitCode != 0 && retryCount != 2)
             {
                 this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
                 this._loggerWrapper.LogWarning(result.StandardError);
-                this._loggerWrapper.LogWarning($"OpenAPI spec generation failed for {outputOpenApiSpecPath}. Retrying once more...");
+                this._loggerWrapper.LogWarning($"OpenAPI spec generation failed for {outputOpenApiSpecPath}. Retrying again...");
 
                 retryCount++;
                 continue;
             }
 
-            if (retryCount == 1 && result.ExitCode != 0)
+            if (retryCount == 2 && result.ExitCode != 0)
             {
-                throw new OpenApiTaskFailedException($"OpenApi file {outputOpenApiSpecPath} could not be created.");
+                throw new OpenApiTaskFailedException($"OpenApi file for {outputOpenApiSpecPath} could not be generated.");
             }
 
             break;

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -6,6 +6,7 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class SwaggerManager : ISwaggerManager
 {
     private const string SwaggerVersion = "6.5.0";
+    private const int MaxRetryCount = 3;
     private readonly IProcessWrapper _processWrapper;
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly string _openApiWebApiAssemblyPath;
@@ -46,57 +47,59 @@ internal sealed class SwaggerManager : ISwaggerManager
             return;
         }
 
-        var retryCount = 0;
-        while (retryCount < 3)
+        var willRetry = true;
+        for (var retryCount = 0; willRetry && retryCount < MaxRetryCount; retryCount++)
         {
             var result = await this._processWrapper.RunProcessAsync(
                 "dotnet",
                 ["tool", "update", "Swashbuckle.AspNetCore.Cli", "--ignore-failed-sources", "--tool-path", this._swaggerDirectory, "--configfile", Path.Combine(this._openApiToolsDirectoryPath, "nuget.config"), "--version", SwaggerVersion],
                 cancellationToken);
 
-            if (result.ExitCode != 0 && retryCount != 2)
+            var isLastRetry = retryCount == MaxRetryCount - 1;
+            if (result.ExitCode != 0)
             {
+                if (isLastRetry)
+                {
+                    throw new OpenApiTaskFailedException("Swashbuckle CLI could not be installed.");
+                }
+
                 this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
                 this._loggerWrapper.LogWarning(result.StandardError);
                 this._loggerWrapper.LogWarning("Swashbuckle download failed. Retrying once more...");
 
-                retryCount++;
                 continue;
             }
 
-            if (retryCount == 2 && result.ExitCode != 0)
-            {
-                throw new OpenApiTaskFailedException("Swashbuckle CLI could not be installed.");
-            }
-
-            break;
+            willRetry = false;
         }
     }
 
     public async Task<string> GenerateOpenApiSpecAsync(string swaggerExePath, string outputOpenApiSpecPath, string documentName, CancellationToken cancellationToken)
     {
         var envVars = new Dictionary<string, string?>() { { "DOTNET_ROLL_FORWARD", "LatestMajor" } };
-        var retryCount = 0;
-        while (retryCount < 3)
-        {
-            var result = await this._processWrapper.RunProcessAsync(swaggerExePath, ["tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName], cancellationToken: cancellationToken, envVars: envVars);
+        var swaggerCancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        swaggerCancellationToken.CancelAfter(TimeSpan.FromMinutes(1));
 
-            if (result.ExitCode != 0 && retryCount != 2)
+        var willRetry = true;
+        for (var retryCount = 0; willRetry && retryCount < MaxRetryCount; retryCount++)
+        {
+            var result = await this._processWrapper.RunProcessAsync(swaggerExePath, ["tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName], cancellationToken: swaggerCancellationToken.Token, envVars: envVars);
+
+            var isLastRetry = retryCount == MaxRetryCount - 1;
+            if (result.ExitCode != 0)
             {
+                if (isLastRetry)
+                {
+                    throw new OpenApiTaskFailedException($"OpenApi file for {outputOpenApiSpecPath} could not be generated.");
+                }
+
                 this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
                 this._loggerWrapper.LogWarning(result.StandardError);
                 this._loggerWrapper.LogWarning($"OpenAPI spec generation failed for {outputOpenApiSpecPath}. Retrying again...");
-
-                retryCount++;
                 continue;
             }
 
-            if (retryCount == 2 && result.ExitCode != 0)
-            {
-                throw new OpenApiTaskFailedException($"OpenApi file for {outputOpenApiSpecPath} could not be generated.");
-            }
-
-            break;
+            willRetry = false;
         }
 
         return outputOpenApiSpecPath;

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -27,7 +27,6 @@ internal sealed class SwaggerManager : ISwaggerManager
     {
         var taskList = new List<Task<string>>();
 
-        // add a retry here for the logs here.
         foreach (var documentName in openApiSwaggerDocumentNames)
         {
             var outputOpenApiSpecName = $"openapi-{documentName.ToLowerInvariant()}.yaml";

--- a/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/SwaggerManager.cs
@@ -47,8 +47,7 @@ internal sealed class SwaggerManager : ISwaggerManager
             return;
         }
 
-        var willRetry = true;
-        for (var retryCount = 0; willRetry && retryCount < MaxRetryCount; retryCount++)
+        for (var retryCount = 0; retryCount < MaxRetryCount; retryCount++)
         {
             var result = await this._processWrapper.RunProcessAsync(
                 "dotnet",
@@ -70,7 +69,7 @@ internal sealed class SwaggerManager : ISwaggerManager
                 continue;
             }
 
-            willRetry = false;
+            break;
         }
     }
 
@@ -81,7 +80,7 @@ internal sealed class SwaggerManager : ISwaggerManager
         swaggerCancellationToken.CancelAfter(TimeSpan.FromMinutes(1));
 
         var willRetry = true;
-        for (var retryCount = 0; willRetry && retryCount < MaxRetryCount; retryCount++)
+        for (var retryCount = 0; retryCount < MaxRetryCount; retryCount++)
         {
             var result = await this._processWrapper.RunProcessAsync(swaggerExePath, ["tofile", "--output", outputOpenApiSpecPath, "--yaml", this._openApiWebApiAssemblyPath, documentName], cancellationToken: swaggerCancellationToken.Token, envVars: envVars);
 
@@ -99,7 +98,7 @@ internal sealed class SwaggerManager : ISwaggerManager
                 continue;
             }
 
-            willRetry = false;
+            break;
         }
 
         return outputOpenApiSpecPath;


### PR DESCRIPTION
## Description of changes
OpenAPI file generation may fail silently during the swagger process. The process seems to time out and the end user is left with no logs for the failure. Thus, we are retrying the spec generation and also adding some High importance logging.

## Breaking changes
None, we added resilience.

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
