### PR TITLE
[IDP-1772] Display Spectral report in ADO CI build extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ For the TLDR version:
 
 - The entry point is `ValidateOpenApiTask.ExecuteAsync()` and will be executed after the referencing project is built. This is defined in `./src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets` as a `UsingTask.TaskName`
 - The default value are defined in the property group on the target `ValidateOpenApi` in this file `./src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets`
-- Users can select whether to validate the API with frontend or backend ruleset depending how they configure the `OpenApiServiceProfile` MSBuild property ([`backend` (default)](https://github.com/gsoft-inc/wl-api-guidelines/blob/main/.spectral.backend.yaml) or [`frontend`](https://github.com/gsoft-inc/wl-api-guidelines/blob/main/.spectral.frontend.yaml)).
+- Users can select whether to validate the API with frontend or backend ruleset depending on how they configure the `OpenApiServiceProfile` MSBuild property ([`backend` (default)](https://github.com/gsoft-inc/wl-api-guidelines/blob/main/.spectral.backend.yaml) or [`frontend`](https://github.com/gsoft-inc/wl-api-guidelines/blob/main/.spectral.frontend.yaml)).
+- Users can configure their CI enviroment for reports depending on how they configure the `OpenApiCiReportEnvironment` MSBuild property (`ado` (default)).
 
 ## How to test locally
 

--- a/src/Workleap.OpenApi.MSBuild/Spectral/AdoCiReportRenderer.cs
+++ b/src/Workleap.OpenApi.MSBuild/Spectral/AdoCiReportRenderer.cs
@@ -1,0 +1,13 @@
+namespace Workleap.OpenApi.MSBuild.Spectral;
+
+internal sealed class AdoCiReportRenderer : ICiReportRenderer
+{
+    public async Task AttachReportToBuildAsync(string reportPath)
+    {
+        // Attach the report to the build summary
+        if (!string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AGENT_NAME")))
+        {
+            Console.WriteLine("##vso[task.addattachment type=Distributedtask.Core.Summary;name=Spectral results;]{0}", reportPath);    
+        }
+    }
+}

--- a/src/Workleap.OpenApi.MSBuild/Spectral/ICiReportRenderer.cs
+++ b/src/Workleap.OpenApi.MSBuild/Spectral/ICiReportRenderer.cs
@@ -1,0 +1,6 @@
+namespace Workleap.OpenApi.MSBuild.Spectral;
+
+internal interface ICiReportRenderer
+{
+    public Task AttachReportToBuildAsync(string reportPath);
+}

--- a/src/Workleap.OpenApi.MSBuild/Spectral/SpectralRunner.cs
+++ b/src/Workleap.OpenApi.MSBuild/Spectral/SpectralRunner.cs
@@ -10,13 +10,15 @@ internal sealed class SpectralRunner
     private readonly ILoggerWrapper _loggerWrapper;
     private readonly IProcessWrapper _processWrapper;
     private readonly DiffCalculator _diffCalculator;
+    private readonly ICiReportRenderer _ciReportRenderer;
     private readonly string _spectralDirectory;
     private readonly string _openApiReportsDirectoryPath;
     
     public SpectralRunner(
         ILoggerWrapper loggerWrapper, 
         IProcessWrapper processWrapper, 
-        DiffCalculator diffCalculator, 
+        DiffCalculator diffCalculator,
+        ICiReportRenderer ciReportRenderer,
         string openApiToolsDirectoryPath, 
         string openApiReportsDirectoryPath)
     {
@@ -25,6 +27,7 @@ internal sealed class SpectralRunner
         this._spectralDirectory = Path.Combine(openApiToolsDirectoryPath, "spectral", SpectralVersion);
         this._processWrapper = processWrapper;
         this._diffCalculator = diffCalculator;
+        this._ciReportRenderer = ciReportRenderer;
     }
     
     public async Task RunSpectralAsync(IReadOnlyCollection<string> openApiDocumentPaths, string spectralExecutablePath, string spectralRulesetPath, CancellationToken cancellationToken)
@@ -50,19 +53,20 @@ internal sealed class SpectralRunner
         foreach (var documentPath in openApiDocumentPaths)
         {
             var documentName = Path.GetFileNameWithoutExtension(documentPath);
-            var htmlReportPath = this.GetReportPath(documentPath);
+            var spectralReportPath = this.GetReportPath(documentPath);
             
             this._loggerWrapper.LogMessage("\n *** Spectral: Validating {0} against ruleset ***", MessageImportance.High, documentName);
             this._loggerWrapper.LogMessage("- File path: {0}", MessageImportance.High, documentPath);
             this._loggerWrapper.LogMessage("- Ruleset : {0}\n", MessageImportance.High, spectralRulesetPath);
 
-            if (File.Exists(htmlReportPath))
+            if (File.Exists(spectralReportPath))
             {
-                this._loggerWrapper.LogMessage("\nDeleting existing report: {0}", messageArgs: htmlReportPath);
-                File.Delete(htmlReportPath);
+                this._loggerWrapper.LogMessage("\nDeleting existing report: {0}", messageArgs: spectralReportPath);
+                File.Delete(spectralReportPath);
             }
             
-            await this.GenerateSpectralReport(spectralExecutePath, documentPath, spectralRulesetPath, htmlReportPath, cancellationToken);
+            await this.GenerateSpectralReport(spectralExecutePath, documentPath, spectralRulesetPath, spectralReportPath, cancellationToken);
+            await this._ciReportRenderer.AttachReportToBuildAsync(spectralReportPath);
             this._loggerWrapper.LogMessage("\n ****************************************************************", MessageImportance.High);
         }
         
@@ -87,11 +91,11 @@ internal sealed class SpectralRunner
     private string GetReportPath(string documentPath)
     {
         var documentName = Path.GetFileNameWithoutExtension(documentPath);
-        var outputSpectralReportName = $"spectral-{documentName}.html";
+        var outputSpectralReportName = $"spectral-{documentName}.txt";
         return Path.Combine(this._openApiReportsDirectoryPath, outputSpectralReportName);
     }
 
-    private async Task GenerateSpectralReport(string spectralExecutePath, string swaggerDocumentPath, string rulesetPath, string htmlReportPath, CancellationToken cancellationToken)
+    private async Task GenerateSpectralReport(string spectralExecutePath, string swaggerDocumentPath, string rulesetPath, string spectralReportPath, CancellationToken cancellationToken)
     {
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -100,7 +104,7 @@ internal sealed class SpectralRunner
         }
 
         this._loggerWrapper.LogMessage("Running Spectral...", MessageImportance.Normal);
-        var result = await this._processWrapper.RunProcessAsync(spectralExecutePath, new[] { "lint", swaggerDocumentPath, "--ruleset", rulesetPath, "--format", "html", "--format", "pretty", "--output.html", htmlReportPath, "--fail-severity=warn", "--verbose" }, cancellationToken);
+        var result = await this._processWrapper.RunProcessAsync(spectralExecutePath, new[] { "lint", swaggerDocumentPath, "--ruleset", rulesetPath, "--format", "stylish", "--output", spectralReportPath, "--fail-severity=warn", "--verbose" }, cancellationToken);
         
         this._loggerWrapper.LogMessage(result.StandardOutput, MessageImportance.High);
         if (!string.IsNullOrEmpty(result.StandardError))
@@ -108,17 +112,17 @@ internal sealed class SpectralRunner
             this._loggerWrapper.LogWarning(result.StandardError);
         }
         
-        if (!File.Exists(htmlReportPath))
+        if (!File.Exists(spectralReportPath))
         {
             throw new OpenApiTaskFailedException($"Spectral report for {swaggerDocumentPath} could not be created. Please check the CONSOLE output above for more details.");
         }
 
         if (result.ExitCode != 0)
         {
-            this._loggerWrapper.LogWarning($"Spectral scan detected violation of ruleset. Please check the report [{htmlReportPath}] for more details.");
+            this._loggerWrapper.LogWarning($"Spectral scan detected violation of ruleset. Please check the report [{spectralReportPath}] for more details.");
         }
 
-        this._loggerWrapper.LogMessage("Spectral report generated. {0}", messageArgs: htmlReportPath);
+        this._loggerWrapper.LogMessage("Spectral report generated. {0}", messageArgs: spectralReportPath);
     }
 
     private async Task AssignExecutePermission(string spectralExecutePath, CancellationToken cancellationToken)

--- a/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
+++ b/src/Workleap.OpenApi.MSBuild/msbuild/tools/Workleap.OpenApi.MSBuild.targets
@@ -6,6 +6,8 @@
     <!-- We use this property when developing this MSBuild task in an IDE, -->
     <!-- so we can reference the task assembly that is built in its bin folder instead of the one in the distributed NuGet package -->
     <OpenApiDebuggingEnabled Condition="'$(OpenApiDebuggingEnabled)' == ''">false</OpenApiDebuggingEnabled>
+    <!-- We use this property to determine the format for spectral report exports for the CI environments -->
+    <OpenApiCiReportEnvironment Condition="'$(OpenApiCiReportEnvironment)' == ''">ado</OpenApiCiReportEnvironment>
     <OpenApiTouchFileName>openapi_spec_validated.txt</OpenApiTouchFileName>
   </PropertyGroup>
 
@@ -83,6 +85,7 @@
       OpenApiSpecificationFiles="$(OpenApiSpecificationFiles)"
       OpenApiTreatWarningsAsErrors="$(OpenApiTreatWarningsAsErrors)"
       OpenApiServiceProfile="$(OpenApiServiceProfile)"
+      OpenApiCiReportEnvironment="$(OpenApiCiReportEnvironment)"
     />
     <Touch Files="$(IntermediateOutputPath)$(OpenApiTouchFileName)" AlwaysCreate="true" />
   </Target>


### PR DESCRIPTION
## Description of changes
We want to display our changes as an ADO pipeline extension automatically instead of manually it as a pipeline step. Basically, when we are done generating a spectral report, we display it using a console command.

## Breaking changes
Users relying on HTML reports will find that their reports are now in Txt format given that ADO is not compatible with HTML..
## Additional checks
Check with a preview version of the library.

- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
