### PR TITLE
[IDP-1037] Add spectral and oasdiff to our renovate monitoring

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "platform": "github",
-  "labels": ["renovate"],
   "extends": [
-    "config:base",
-    ":rebaseStalePrs"
-  ],
-  "enabledManagers": [
-    "github-actions",
-    "nuget",
-    "custom.regex"
+    "github>gsoft-inc/renovate-config"
   ],
   "stabilityDays": 3,
-  "prHourlyLimit": 0,
-  "prConcurrentLimit": 0,
-  "branchConcurrentLimit": 0,
-  "dependencyDashboard": false,
-  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
   "packageRules": [
     {
       "matchManagers": ["nuget"],
@@ -25,16 +13,10 @@
     },
     {
       "matchManagers": ["nuget"],
-      "matchPackagePatterns": ["^Microsoft\\.(Extensions|AspNetCore|SourceLink)\\.", "^System\\.", "^Microsoft\\.CodeAnalysis\\.CSharp\\."],
+      "matchPackagePatterns": ["^Microsoft\\.(Extensions|AspNetCore)\\.", "^System\\.", "^Microsoft\\.CodeAnalysis\\.CSharp\\."],
       "groupName": "Ignored NuGet dependencies",
       "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",
       "enabled": false
-    },
-    {
-      "matchPackageNames": ["dotnet-sdk"],
-      "groupName": "Dotnet SDK",
-      "description": "Only update patch and minor for the dotnet SDK version within the global.json",
-      "extends": [":disableMajorUpdates"]
     },
     {
       "matchManagers": ["github-actions"],
@@ -64,9 +46,5 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "Tufin/oasdiff"
     }
-  ],
-  "vulnerabilityAlerts": {
-    "enabled": true,
-    "labels": ["security"]
-  }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,47 +1,72 @@
 {
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "platform": "github",
-    "labels": ["renovate"],
-    "extends": [
-      "config:base",
-      ":rebaseStalePrs"
-    ],
-    "enabledManagers": [
-      "github-actions",
-      "nuget"
-    ],
-    "stabilityDays": 3,
-    "prHourlyLimit": 0,
-    "prConcurrentLimit": 0,
-    "branchConcurrentLimit": 0,
-    "dependencyDashboard": false,
-    "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
-    "packageRules": [
-      {
-        "matchManagers": ["nuget"],
-        "excludePackagePatterns": ["^Microsoft\\.Extensions\\.", "^System\\.", "^dotnet-sdk$", "^Microsoft\\.CodeAnalysis\\.CSharp\\."],
-        "groupName": "NuGet dependencies"
-      },
-      {
-        "matchManagers": ["nuget"],
-        "matchPackagePatterns": ["^Microsoft\\.(Extensions|AspNetCore|SourceLink)\\.", "^System\\.", "^Microsoft\\.CodeAnalysis\\.CSharp\\."],
-        "groupName": "Ignored NuGet dependencies",
-        "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",
-        "enabled": false
-      },
-      {
-        "matchPackageNames": ["dotnet-sdk"],
-        "groupName": "Dotnet SDK",
-        "description": "Only update patch and minor for the dotnet SDK version within the global.json",
-        "extends": [":disableMajorUpdates"]
-      },
-      {
-        "matchManagers": ["github-actions"],
-        "groupName": "Pipeline dependencies"
-      }
-    ],
-    "vulnerabilityAlerts": {
-      "enabled": true,
-      "labels": ["security"]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "platform": "github",
+  "labels": ["renovate"],
+  "extends": [
+    "config:base",
+    ":rebaseStalePrs"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "nuget",
+    "custom.regex"
+  ],
+  "stabilityDays": 3,
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0,
+  "branchConcurrentLimit": 0,
+  "dependencyDashboard": false,
+  "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+  "packageRules": [
+    {
+      "matchManagers": ["nuget"],
+      "excludePackagePatterns": ["^Microsoft\\.Extensions\\.", "^System\\.", "^dotnet-sdk$", "^Microsoft\\.CodeAnalysis\\.CSharp\\."],
+      "groupName": "NuGet dependencies"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackagePatterns": ["^Microsoft\\.(Extensions|AspNetCore|SourceLink)\\.", "^System\\.", "^Microsoft\\.CodeAnalysis\\.CSharp\\."],
+      "groupName": "Ignored NuGet dependencies",
+      "description": "These packages are usually set to a user-defined minimal supported version such as 6.0.0 for .NET 6, and they are overriden by consuming applications",
+      "enabled": false
+    },
+    {
+      "matchPackageNames": ["dotnet-sdk"],
+      "groupName": "Dotnet SDK",
+      "description": "Only update patch and minor for the dotnet SDK version within the global.json",
+      "extends": [":disableMajorUpdates"]
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "Pipeline dependencies"
     }
+  ],
+  "customManagers": [
+    {
+      "description": "Custom manager for renovating spectral version listed in .cs files",
+      "customType": "regex",
+      "fileMatch": ["\\.cs$"],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "private const string SpectralVersion = \"(?<currentValue>[^\"]+)\";"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "stoplightio/spectral"
+    },
+    {
+      "description": "Custom manager for renovating oasdiff version listed in .cs files",
+      "customType": "regex",
+      "fileMatch": ["\\.cs$"],
+      "matchStringsStrategy": "any",
+      "matchStrings": [
+        "private const string OasdiffVersion = \"(?<currentValue>[^\"]+)\";"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "Tufin/oasdiff"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
   }
+}

--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -5,6 +5,7 @@ namespace Workleap.OpenApi.MSBuild;
 
 internal sealed class OasdiffManager : IOasdiffManager
 {
+    // If the line below changes, make sure to update the corresponding regex on the renovate.json file
     private const string OasdiffVersion = "1.10.11";
     private const string OasdiffDownloadUrlFormat = "https://github.com/Tufin/oasdiff/releases/download/v{0}/{1}";
 

--- a/src/Workleap.OpenApi.MSBuild/Spectral/SpectralInstaller.cs
+++ b/src/Workleap.OpenApi.MSBuild/Spectral/SpectralInstaller.cs
@@ -2,6 +2,7 @@
 
 internal class SpectralInstaller
 {
+    // If the line below changes, make sure to update the corresponding regex on the renovate.json file
     private const string SpectralVersion = "6.11.0";
     private const string SpectralDownloadUrlFormat = "https://github.com/stoplightio/spectral/releases/download/v{0}/{1}";
 

--- a/src/Workleap.OpenApi.MSBuild/Spectral/SpectralRunner.cs
+++ b/src/Workleap.OpenApi.MSBuild/Spectral/SpectralRunner.cs
@@ -5,6 +5,7 @@ namespace Workleap.OpenApi.MSBuild.Spectral;
 
 internal sealed class SpectralRunner
 {
+    // If the line below changes, make sure to update the corresponding regex on the renovate.json file
     private const string SpectralVersion = "6.11.0";
 
     private readonly ILoggerWrapper _loggerWrapper;


### PR DESCRIPTION
## Description of changes
Use renovate to monitor the versions of Spectral and Oasdiff which are release as part of github-tags.

## Breaking changes
None.

## Additional checks
![image](https://github.com/user-attachments/assets/10f4b47a-5703-49af-8e0c-e48197539156)


- [ ] Updated the documentation of the project to reflect the changes
- [ ] Added new tests that cover the code changes
