### PR TITLE
[IDP-2061] Fix Nuget Duplication in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
       - "feature/**"
   
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{  github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,11 @@ on:
   push:
     branches:
       - "renovate/**"
-      - "feature/**"
 
 # Prevent duplicate runs if Renovate falls back to creating a PR
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 jobs:
   ci:
@@ -21,20 +20,6 @@ jobs:
 
 
     steps:
-      - name: Log GitHub Context Variables
-        run: |
-          echo "head_ref: ${{ github.head_ref }}"
-          echo "ref_name: ${{ github.ref_name }}"
-          echo "ref: ${{ github.ref }}"
-          echo "sha: ${{ github.sha }}"
-          echo "workflow: ${{ github.workflow }}"
-          echo "event_name: ${{ github.event_name }}"
-          echo "actor: ${{ github.actor }}"
-          echo "repository: ${{ github.repository }}"
-          echo "repository_owner: ${{ github.repository_owner }}"
-          echo "run_id: ${{ github.run_id }}"
-          echo "run_number: ${{ github.run_number }}"    
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
     branches:
       - "renovate/**"
 
-# Prevent duplicate runs if renovate fallback to create a PR
+# Prevent duplicate runs if Renovate falls back to creating a PR
 concurrency:
   group: ${{ github.workflow }}-${{  github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 # Prevent duplicate runs if Renovate falls back to creating a PR
 concurrency:
-  group: ${{ github.workflow }}-${{  github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,12 @@ on:
   push:
     branches:
       - "renovate/**"
+      - "feature/**"
   
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,17 +8,33 @@ on:
   push:
     branches:
       - "renovate/**"
+      - "feature/**"
 
 # Prevent duplicate runs if Renovate falls back to creating a PR
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+#   cancel-in-progress: true
 
 jobs:
   ci:
     runs-on: ubuntu-latest
 
+
     steps:
+      - name: Log GitHub Context Variables
+        run: |
+          echo "head_ref: ${{ github.head_ref }}"
+          echo "ref_name: ${{ github.ref_name }}"
+          echo "ref: ${{ github.ref }}"
+          echo "sha: ${{ github.sha }}"
+          echo "workflow: ${{ github.workflow }}"
+          echo "event_name: ${{ github.event_name }}"
+          echo "actor: ${{ github.actor }}"
+          echo "repository: ${{ github.repository }}"
+          echo "repository_owner: ${{ github.repository_owner }}"
+          echo "run_id: ${{ github.run_id }}"
+          echo "run_number: ${{ github.run_number }}"    
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,8 +8,8 @@ on:
   push:
     branches:
       - "renovate/**"
-      - "feature/**"
-  
+
+# Prevent duplicate runs if renovate fallback to create a PR
 concurrency:
   group: ${{ github.workflow }}-${{  github.head_ref || github.ref_name }}
   cancel-in-progress: true

--- a/Build.ps1
+++ b/Build.ps1
@@ -26,7 +26,7 @@ Process {
         Exec { & dotnet pack -c Release -o "$outputDir" }
 
         if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
-            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY }
+            Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }
         }
     }
     finally {


### PR DESCRIPTION
## Description of changes

- Skip nuget push duplicate. 
- Setup concurrency option to prevent duplicate run when Renovate falls back to creating a PR