### PR TITLE
[IDP-2866] Revert Oasdiff version to v1.x

### DIFF
--- a/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
+++ b/src/Workleap.OpenApi.MSBuild/OasdiffManager.cs
@@ -6,7 +6,8 @@ namespace Workleap.OpenApi.MSBuild;
 internal sealed class OasdiffManager : IOasdiffManager
 {
     // If the line below changes, make sure to update the corresponding regex on the renovate.json file
-    private const string OasdiffVersion = "2.1.2";
+    // Do not upgrade to v2.x as it is an older version with breaking changes
+    private const string OasdiffVersion = "1.10.27";
     private const string OasdiffDownloadUrlFormat = "https://github.com/Tufin/oasdiff/releases/download/v{0}/{1}";
 
     private readonly ILoggerWrapper _loggerWrapper;


### PR DESCRIPTION
## Description of changes
Oasdiff was upgraded to v2.x and that was actually and older version with a breaking change. Reverting to V1.x solved the local build issues.

## Breaking changes
None